### PR TITLE
fix: use video as example

### DIFF
--- a/src/components/GettingStartedSection/GettingStartedSection.tsx
+++ b/src/components/GettingStartedSection/GettingStartedSection.tsx
@@ -44,17 +44,16 @@ export const GettingStartedSectionBase = ({
     reached25: false,
     reached50: false,
     reached75: false,
-    reached100: false,
   });
 
-  const handleVideoPlay = () => {
+  const handleVideoPlay = useCallback(() => {
     const state = videoProgressRef.current;
 
     if (!state.hasStarted) {
       state.hasStarted = true;
       trackGoal("ide_video_play");
     }
-  };
+  }, []);
 
   const handleVideoTimeUpdate = useCallback(
     (event: SyntheticEvent<HTMLVideoElement>) => {
@@ -84,13 +83,16 @@ export const GettingStartedSectionBase = ({
     []
   );
 
-  const handleVideoEnded = (event: SyntheticEvent<HTMLVideoElement>) => {
-    const { duration } = event.currentTarget;
+  const handleVideoEnded = useCallback(
+    (event: SyntheticEvent<HTMLVideoElement>) => {
+      const { duration } = event.currentTarget;
 
-    if (!duration || Number.isNaN(duration)) return;
+      if (!duration || Number.isNaN(duration)) return;
 
-    trackGoal("ide_video_complete", { duration });
-  };
+      trackGoal("ide_video_complete", { duration });
+    },
+    []
+  );
 
   return (
     <section className="section">


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Replaced static image with video element for IDE configuration demonstration and added comprehensive analytics tracking for video engagement metrics (play, progress milestones, completion).

**Key Changes:**
- Swapped Next.js `Image` component for native HTML5 `video` element with external video source (Yandex Cloud storage)
- Added video state tracking via `useRef` to monitor play events and progress milestones (25%, 50%, 75%)
- Integrated Yandex Metrika analytics calls to track user engagement with the video

**Issues Found:**
- Unused `reached100` field in state object (defined but never tracked)
- Inconsistent use of `useCallback` across event handlers (only `handleVideoTimeUpdate` is memoized)
- Existing issues from previous review still apply (ref mutation pattern, `onTimeUpdate` performance, 100% check reliability)

<h3>Confidence Score: 3/5</h3>


- Safe to merge with minor style issues that don't affect functionality
- The PR successfully implements video playback with analytics tracking without introducing critical bugs. The main concerns are style-related (unused field, inconsistent memoization) rather than functional. Previous comments identified more significant issues (ref mutation, onTimeUpdate performance) but these are non-blocking style concerns for React best practices.
- No files require special attention - only minor style improvements suggested

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/components/GettingStartedSection/GettingStartedSection.tsx | 3/5 | Replaced static image with video element and added analytics tracking for video playback events (play, progress at 25/50/75%, completion) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VideoElement
    participant Component
    participant videoProgressRef
    participant trackGoal as Analytics (trackGoal)
    
    User->>VideoElement: Opens details section
    VideoElement->>VideoElement: autoPlay starts video
    VideoElement->>Component: onPlay event
    Component->>videoProgressRef: Check hasStarted
    alt First play
        Component->>videoProgressRef: Set hasStarted = true
        Component->>trackGoal: Track "ide_video_play"
    end
    
    loop Video playback
        VideoElement->>Component: onTimeUpdate event (multiple times/sec)
        Component->>Component: Calculate percent = (currentTime/duration)*100
        Component->>videoProgressRef: Check progress flags
        
        alt percent >= 25 && !reached25
            Component->>videoProgressRef: Set reached25 = true
            Component->>trackGoal: Track "ide_video_progress" {25%, time, duration}
        end
        
        alt percent >= 50 && !reached50
            Component->>videoProgressRef: Set reached50 = true
            Component->>trackGoal: Track "ide_video_progress" {50%, time, duration}
        end
        
        alt percent >= 75 && !reached75
            Component->>videoProgressRef: Set reached75 = true
            Component->>trackGoal: Track "ide_video_progress" {75%, time, duration}
        end
    end
    
    User->>VideoElement: Video finishes
    VideoElement->>Component: onEnded event
    Component->>trackGoal: Track "ide_video_complete" {duration}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->