### PR TITLE
feat: status badge

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
   --fg: #ffffff;
   --muted: rgba(255, 255, 255, 0.5);
   --acc: #ffbe5c;
+  --danger: #ff4d4f;
   --pill-bg: rgba(255, 255, 255, 0.1);
   --pill-border: rgba(255, 255, 255, 0.15);
 }
@@ -449,6 +450,38 @@ details figure img {
   .copy-btn {
     align-self: auto;
   }
+}
+
+.demo-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.demo-status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--muted);
+  flex-shrink: 0;
+}
+
+.demo-status--up .demo-status-indicator {
+  background: var(--acc);
+}
+
+.demo-status--down .demo-status-indicator {
+  background: var(--danger);
+}
+
+.demo-status--down {
+  color: var(--danger);
+}
+
+.demo-status-text {
+  white-space: nowrap;
 }
 
 .copy-btn {

--- a/src/components/DemoEndpointBadge.tsx
+++ b/src/components/DemoEndpointBadge.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { MouseEvent, ReactNode } from "react";
+import { ServiceStatus } from "@/components/ServiceStatus";
+
+export type DemoEndpointBadgeProps = {
+  label: ReactNode;
+  url: string;
+  buttonLabel: string;
+  onCopy: (event: MouseEvent<HTMLButtonElement>) => void;
+  locale?: "en" | "ru";
+};
+
+export function DemoEndpointBadge({
+  label,
+  url,
+  buttonLabel,
+  onCopy,
+  locale = "en",
+}: DemoEndpointBadgeProps) {
+  return (
+    <div className="hero-demo">
+      {label} <code>{url}</code>
+      <button type="button" className="copy-btn" onClick={onCopy}>
+        {buttonLabel}
+      </button>
+      <ServiceStatus locale={locale} />
+    </div>
+  );
+}
+
+

--- a/src/components/DocsPage/DocsPage.tsx
+++ b/src/components/DocsPage/DocsPage.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Dialog, Button, Icon } from "@gravity-ui/uikit";
 import { ArrowLeft } from "@gravity-ui/icons";
 import { createCopyToClipboardHandler } from "@/shared/utils/copyToClipboard";
+import { DemoEndpointBadge } from "@/components/DemoEndpointBadge";
 
 export const DEMO_URL = "http://ydb-qdrant.tech:8080";
 
@@ -58,16 +59,13 @@ export const DocsPageBase = ({
       </div>
       <h1>{title}</h1>
       <p className="lead">{lead}</p>
-      <p className="hero-demo">
-        {demoPrefix} <code>{DEMO_URL}</code>
-        <button
-          type="button"
-          className="copy-btn"
-          onClick={(e) => handleCopy(DEMO_URL, e)}
-        >
-          {copyButtonLabel}
-        </button>
-      </p>
+      <DemoEndpointBadge
+        label={demoPrefix}
+        url={DEMO_URL}
+        buttonLabel={copyButtonLabel}
+        onCopy={(e) => handleCopy(DEMO_URL, e)}
+        locale={metricsPageName === "docs-ru" ? "ru" : "en"}
+      />
 
       {sections.map((section) => (
         <section className="section" key={section.title}>

--- a/src/components/GettingStartedSection/GettingStartedSection.tsx
+++ b/src/components/GettingStartedSection/GettingStartedSection.tsx
@@ -1,9 +1,17 @@
 import type { MouseEvent, ReactNode, RefObject, SyntheticEvent } from "react";
 import { useCallback, useEffect, useRef } from "react";
 import Image from "next/image";
-import { Card, Link, TabProvider, TabList, Tab, TabPanel } from "@gravity-ui/uikit";
+import {
+  Card,
+  Link,
+  TabProvider,
+  TabList,
+  Tab,
+  TabPanel,
+} from "@gravity-ui/uikit";
 import { SectionTitleWithAnchor } from "../SectionTitleWithAnchor/SectionTitleWithAnchor";
 import { trackGoal } from "@/shared/utils/metricsManager";
+import { DemoEndpointBadge } from "@/components/DemoEndpointBadge";
 
 export type DocsLink = {
   href: string;
@@ -14,6 +22,7 @@ export type GettingStartedSectionBaseProps = {
   sectionRef?: RefObject<HTMLElement | null>;
   activeTab: string;
   onTabChange: (tab: string) => void;
+  locale?: "en" | "ru";
   title: string;
   ideConfigSummary: string;
   ideConfigDescription: ReactNode;
@@ -40,6 +49,7 @@ export const GettingStartedSectionBase = ({
   sectionRef,
   activeTab,
   onTabChange,
+  locale = "en",
   title,
   ideConfigSummary,
   ideConfigDescription,
@@ -260,15 +270,14 @@ export const GettingStartedSectionBase = ({
                   aria-label={ideConfigImageAlt}
                 />
               </figure>
-              <div style={{ marginTop: 24, fontSize: 16 }} className="hero-demo">
-                {optionsHosted} <code>{demoUrl}</code>
-                <button
-                  type="button"
-                  className="copy-btn"
-                  onClick={onCopyDemoUrl}
-                >
-                  Copy
-                </button>
+              <div style={{ marginTop: 24, fontSize: 16 }}>
+                <DemoEndpointBadge
+                  label={optionsHosted}
+                  url={demoUrl}
+                  buttonLabel={locale === "ru" ? "Копировать" : "Copy"}
+                  onCopy={onCopyDemoUrl}
+                  locale={locale}
+                />
               </div>
               {ideConfigDescription}
             </Card>

--- a/src/components/GettingStartedSection/index.tsx
+++ b/src/components/GettingStartedSection/index.tsx
@@ -17,6 +17,7 @@ export const GettingStartedSectionEn = ({
       activeTab={activeTab}
       onTabChange={onTabChange}
       onCopyDemoUrl={onCopyDemoUrl}
+      locale="en"
       {...gettingStartedSectionEnProps()}
     />
   );
@@ -34,6 +35,7 @@ export const GettingStartedSectionRu = ({
       activeTab={activeTab}
       onTabChange={onTabChange}
       onCopyDemoUrl={onCopyDemoUrl}
+      locale="ru"
       {...gettingStartedSectionRuProps()}
     />
   );

--- a/src/components/GettingStartedSection/locales.tsx
+++ b/src/components/GettingStartedSection/locales.tsx
@@ -324,7 +324,7 @@ const client = createYdbQdrantClient({
       "Поток запросов: IDE/Agent → ydb-qdrant (Node.js) → YDB векторы + индекс",
     optionsTitle: "Варианты",
     optionsSelfHost: "Самостоятельный хостинг: http://localhost:8080/",
-    optionsHosted: "Хостируемый demo‑endpoint для IDE:",
+    optionsHosted: "Публичный demo‑endpoint для IDE:",
     demoUrl,
     docsTitle: "Документация",
     docsLinks,

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -2,6 +2,7 @@ import type { MouseEvent } from "react";
 import Image from "next/image";
 import { Button, Link } from "@gravity-ui/uikit";
 import { trackGoal } from "@/shared/utils/metricsManager";
+import { DemoEndpointBadge } from "@/components/DemoEndpointBadge";
 
 export type HeroContent = {
   title: string;
@@ -19,12 +20,14 @@ export type HeroSectionBaseProps = {
   content: HeroContent;
   onOpenIdeDetails: (scrollSmooth: boolean) => void;
   onCopyDemoUrl: (event: MouseEvent<HTMLButtonElement>) => void;
+  locale?: "en" | "ru";
 };
 
 export const HeroSectionBase = ({
   content,
   onOpenIdeDetails,
   onCopyDemoUrl,
+  locale = "en",
 }: HeroSectionBaseProps) => {
   return (
     <section className="hero">
@@ -73,16 +76,13 @@ export const HeroSectionBase = ({
           {content.docsLabel}
         </Link>
       </div>
-      <p className="hero-demo">
-        {content.demoPrefix} <code>http://ydb-qdrant.tech:8080</code>
-        <button
-          type="button"
-          className="copy-btn"
-          onClick={onCopyDemoUrl}
-        >
-          {content.demoButtonLabel}
-        </button>
-      </p>
+      <DemoEndpointBadge
+        label={content.demoPrefix}
+        url="http://ydb-qdrant.tech:8080"
+        buttonLabel={content.demoButtonLabel}
+        onCopy={onCopyDemoUrl}
+        locale={locale}
+      />
       <p className="hero-footnote">{content.footnote}</p>
     </section>
   );

--- a/src/components/HeroSection/index.tsx
+++ b/src/components/HeroSection/index.tsx
@@ -6,11 +6,23 @@ import {
 } from "./locales";
 
 export const HeroSectionEn = (props: HeroSectionPublicProps) => {
-  return <HeroSectionBase {...props} content={heroSectionEnContent} />;
+  return (
+    <HeroSectionBase
+      {...props}
+      content={heroSectionEnContent}
+      locale="en"
+    />
+  );
 };
 
 export const HeroSectionRu = (props: HeroSectionPublicProps) => {
-  return <HeroSectionBase {...props} content={heroSectionRuContent} />;
+  return (
+    <HeroSectionBase
+      {...props}
+      content={heroSectionRuContent}
+      locale="ru"
+    />
+  );
 };
 
 export { HeroSectionBase } from "./HeroSection";

--- a/src/components/ServiceStatus.tsx
+++ b/src/components/ServiceStatus.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { YDB_QDRANT_BASE_URL } from "@/shared/config";
+
+type ServiceStatusValue = "unknown" | "up" | "down";
+
+type ServiceStatusProps = {
+  locale?: "en" | "ru";
+};
+
+const STATUS_CHECK_INTERVAL = 30000;
+
+export function ServiceStatus({ locale = "en" }: ServiceStatusProps) {
+  const [status, setStatus] = useState<ServiceStatusValue>("unknown");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchStatus() {
+      try {
+        const res = await fetch(`${YDB_QDRANT_BASE_URL}/health`);
+        if (!cancelled) {
+          setStatus(res.ok ? "up" : "down");
+        }
+      } catch {
+        if (!cancelled) {
+          setStatus("down");
+        }
+      }
+    }
+
+    void fetchStatus();
+
+    const intervalId = window.setInterval(() => {
+      void fetchStatus();
+    }, STATUS_CHECK_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  let label: string;
+  if (locale === "ru") {
+    if (status === "up") {
+      label = "Онлайн";
+    } else if (status === "down") {
+      label = "Недоступен";
+    } else {
+      label = "Проверяем…";
+    }
+  } else {
+    if (status === "up") {
+      label = "Online";
+    } else if (status === "down") {
+      label = "Offline";
+    } else {
+      label = "Checking…";
+    }
+  }
+
+  return (
+    <span
+      className={`demo-status demo-status--${status}`}
+      aria-live="polite"
+    >
+      <span className="demo-status-indicator" aria-hidden="true" />
+      <span className="demo-status-text">{label}</span>
+    </span>
+  );
+}
+
+

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,0 +1,4 @@
+export const YDB_QDRANT_BASE_URL =
+  process.env.NEXT_PUBLIC_YDB_QDRANT_BASE_URL ?? "http://ydb-qdrant.tech:8080";
+
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds a real-time status badge to demo endpoints that checks service health every 30 seconds. The changes refactor duplicated demo endpoint UI into a reusable `DemoEndpointBadge` component that displays an online/offline indicator alongside the URL and copy button.

**Key Changes:**
- Created `ServiceStatus` component with automatic health checks using fetch to `/health` endpoint
- Extracted `DemoEndpointBadge` reusable component with integrated status display
- Added centralized config in `src/shared/config.ts` for base URL
- Implemented proper cleanup for intervals to prevent memory leaks
- Added CSS styling for status indicators with color variables (`--danger`, `--acc`)
- Integrated status badge across Hero, Docs, and Getting Started sections with locale support

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The implementation follows React best practices with proper cleanup, good component extraction, and sensible error handling. No logical errors, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/components/ServiceStatus.tsx | 5/5 | Added new component to check service health every 30s and display online/offline status with proper cleanup |
| src/components/DemoEndpointBadge.tsx | 5/5 | Extracted reusable component for demo endpoint display with copy button and status badge |
| src/shared/config.ts | 5/5 | Added centralized config for base URL with environment variable support |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DemoEndpointBadge
    participant ServiceStatus
    participant HealthEndpoint as Health Endpoint<br/>(YDB_QDRANT_BASE_URL/health)

    User->>DemoEndpointBadge: View page with demo endpoint
    DemoEndpointBadge->>ServiceStatus: Render with locale prop
    
    activate ServiceStatus
    ServiceStatus->>ServiceStatus: Set initial status = "unknown"
    ServiceStatus->>HealthEndpoint: fetch(/health) [initial check]
    
    alt Health check succeeds
        HealthEndpoint-->>ServiceStatus: 200 OK
        ServiceStatus->>ServiceStatus: Set status = "up"
        ServiceStatus->>User: Display "Online" with green indicator
    else Health check fails
        HealthEndpoint-->>ServiceStatus: Error / Non-OK response
        ServiceStatus->>ServiceStatus: Set status = "down"
        ServiceStatus->>User: Display "Offline" with red indicator
    end
    
    ServiceStatus->>ServiceStatus: Start 30s interval timer
    
    loop Every 30 seconds
        ServiceStatus->>HealthEndpoint: fetch(/health)
        alt Service is up
            HealthEndpoint-->>ServiceStatus: 200 OK
            ServiceStatus->>ServiceStatus: Update status = "up"
            ServiceStatus->>User: Update to "Online"
        else Service is down
            HealthEndpoint-->>ServiceStatus: Error
            ServiceStatus->>ServiceStatus: Update status = "down"
            ServiceStatus->>User: Update to "Offline"
        end
    end
    
    User->>DemoEndpointBadge: Navigate away / unmount
    DemoEndpointBadge->>ServiceStatus: Unmount component
    ServiceStatus->>ServiceStatus: Cleanup: cancel=true, clearInterval
    deactivate ServiceStatus
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->