### PR TITLE
fix: update why-section

### DIFF
--- a/src/components/WhySection/WhySection.scss
+++ b/src/components/WhySection/WhySection.scss
@@ -1,0 +1,69 @@
+@use '../../styles/mixins' as *;
+
+.why-section {
+  &__table-card {
+    margin-top: var(--spacing-xl);
+    border: 1px solid var(--pill-border);
+    border-radius: var(--radius-lg);
+    background: transparent;
+    overflow: hidden;
+
+    @include sm {
+      margin-top: var(--spacing-2xl);
+    }
+  }
+
+  &__table {
+    width: 100%;
+
+    .g-table__table {
+      table-layout: fixed;
+      width: 100%;
+    }
+
+    // Header styling
+    .g-table__head .g-table__cell {
+      background-color: var(--pill-bg);
+      font-weight: 600;
+      color: var(--fg);
+      border-bottom: 1px solid var(--pill-border);
+      padding-top: var(--spacing-md);
+      padding-bottom: var(--spacing-md);
+    }
+
+    // Body styling
+    .g-table__body {
+      .g-table__row {
+        &:not(:last-child) .g-table__cell {
+          border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+        }
+        
+        // Hover effect on rows
+        @include hover {
+          &:hover .g-table__cell {
+            background-color: rgba(255, 255, 255, 0.03);
+          }
+        }
+      }
+    }
+
+    .g-table__cell {
+      padding-top: var(--spacing-md);
+      padding-bottom: var(--spacing-md);
+    }
+  }
+
+  &__col-feature {
+    font-weight: 600;
+  }
+
+  &__col-highlight {
+    background-color: rgba(255, 190, 92, 0.04);
+    color: var(--acc);
+    font-weight: 500;
+  }
+
+  &__col-regular {
+    color: var(--muted);
+  }
+}

--- a/src/components/WhySection/WhySection.tsx
+++ b/src/components/WhySection/WhySection.tsx
@@ -1,5 +1,6 @@
 import { Card, Text, Table } from "@gravity-ui/uikit";
 import { SectionTitleWithAnchor } from "../SectionTitleWithAnchor/SectionTitleWithAnchor";
+import "./WhySection.scss";
 
 type WhyCard = {
   title: string;
@@ -50,16 +51,37 @@ export const WhySectionBase = ({
       <h3 className="section-title" style={{ marginTop: 48 }}>
         {comparisonTitle}
       </h3>
-      <div style={{ overflowX: "auto" }}>
-        <Table
-          columns={[
-            { id: "feature", name: comparisonHeaders.feature },
-            { id: "ydbQdrant", name: comparisonHeaders.ydbQdrant },
-            { id: "qdrant", name: comparisonHeaders.qdrant },
-          ]}
-          data={comparisonRows}
-          edgePadding={false}
-        />
+      <div className="why-section__table-card">
+        <div style={{ overflowX: "auto" }}>
+          <Table
+            className="why-section__table"
+            width="max"
+            columns={[
+              {
+                id: "feature",
+                name: comparisonHeaders.feature,
+                className: "why-section__col-feature",
+                width: "34%"
+              },
+              {
+                id: "ydbQdrant",
+                name: comparisonHeaders.ydbQdrant,
+                className: "why-section__col-highlight",
+                width: "33%"
+              },
+              {
+                id: "qdrant",
+                name: comparisonHeaders.qdrant,
+                className: "why-section__col-regular",
+                width: "33%"
+              },
+            ]}
+            data={comparisonRows}
+            edgePadding={true}
+            wordWrap={true}
+            verticalAlign="middle"
+          />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reskins the comparison table in `WhySection` by wrapping it in a styled card (`why-section__table-card`), adding column-level class names, widths, word-wrap, and vertical alignment. A new `WhySection.scss` file provides the visual styling.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no runtime or correctness impact.

The changes are purely presentational: wrapping a table in a styled container and adding column classNames/widths. No logic, data flow, or API contracts are modified. All three findings (b() utility, hardcoded RGBA values, internal g-table class targeting) are quality/style improvements for future maintainability, not blocking defects.

No files require special attention for merge; the SCSS issues are worth addressing in a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/WhySection/WhySection.tsx | Refactors comparison table into a styled card wrapper; adds column-level classNames, widths, wordWrap, and verticalAlign props — uses hardcoded class name strings instead of the team's b() utility |
| src/components/WhySection/WhySection.scss | New SCSS file with BEM structure for the table card; relies on Gravity UI internal classes and contains hardcoded dark-mode RGBA values outside the design token system |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[WhySectionBase] --> B[section.section]
    B --> C[SectionTitleWithAnchor]
    B --> D[div.grid — feature cards]
    D --> E[Card × N]
    B --> F["h3.section-title — comparisonTitle"]
    B --> G["div.why-section__table-card ✨ new"]
    G --> H[div — overflowX auto]
    H --> I["Table.why-section__table ✨ new"]
    I --> J["col: feature (why-section__col-feature)"]
    I --> K["col: ydbQdrant (why-section__col-highlight)"]
    I --> L["col: qdrant (why-section__col-regular)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/WhySection/WhySection.tsx
Line: 54-84

Comment:
**Hardcoded class names instead of `b()` utility**

Column and wrapper class names are passed as raw strings (`"why-section__col-feature"`, `"why-section__table-card"`, etc.) instead of using the `b()` BEM utility function. The team's convention requires `b()` for all CSS class names to ensure consistent BEM generation and avoid typos.

**Rule Used:** Use the BEM naming convention with the `b()` utili... ([source](https://app.greptile.com/review/custom-context?memory=2bea9cbf-2d5a-4f2d-8669-abfdb73f2fc4))

**Learned From**
[ydb-platform/ydb-embedded-ui#2899](https://github.com/ydb-platform/ydb-embedded-ui/pull/2899)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/WhySection/WhySection.scss
Line: 38-44

Comment:
**Hardcoded RGBA values bypass design-token system**

Lines 38 and 61 use hardcoded `rgba(255, 255, 255, ...)` values that assume a dark background, while the rest of the file correctly uses design tokens (`var(--pill-border)`, `var(--acc)`, `var(--muted)`). If a light theme is ever enabled these overlays will produce invisible or incorrect colors. Consider replacing with appropriate CSS variables.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/WhySection/WhySection.scss
Line: 19-53

Comment:
**Targeting Gravity UI internal classes is fragile**

Styles are applied by targeting Gravity UI's internal BEM classes (`.g-table__table`, `.g-table__head`, `.g-table__cell`, `.g-table__row`, `.g-table__body`). These are implementation details of the library; a version bump that renames these selectors will silently break the layout with no TypeScript or build error. Prefer using the `className`/`headerClassName`/`bodyClassName` props on the `Table` and column definitions to inject classes that you own, then style those classes.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update why-section"](https://github.com/astandrik/ydb-qdrant-ui/commit/70346c0b1d73e02ed94dd1d6f920f2d76a9b8599) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29143307)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - Use the BEM naming convention with the `b()` utili... ([source](https://app.greptile.com/review/custom-context?memory=2bea9cbf-2d5a-4f2d-8669-abfdb73f2fc4))

**Learned From**
[ydb-platform/ydb-embedded-ui#2899](https://github.com/ydb-platform/ydb-embedded-ui/pull/2899)

<!-- /greptile_comment -->