### PR TITLE
Add local-ydb project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ lerna-debug.log*
 .env.production.local
 
 # sensitive files
+private/
 *.key
 *.pem
 *.p12

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from "next";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   output: "export",
   trailingSlash: true,
+  turbopack: {
+    root: projectRoot,
+  },
 };
 
 export default nextConfig;

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ThemeProvider } from "@gravity-ui/uikit";
+
+const THEME = "dark" as const;
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={THEME}>{children}</ThemeProvider>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import "@gravity-ui/uikit/styles/fonts.css";
 import "@gravity-ui/uikit/styles/styles.css";
 import "@/styles/globals.scss";
 import YandexMetrika from "./YandexMetrika";
-import { ThemeProvider } from "@gravity-ui/uikit";
 import { getRootClassName } from "@gravity-ui/uikit/server";
+import { Providers } from "./Providers";
 import Footer from "@/components/Footer";
 
 const geistSans = Geist({
@@ -76,10 +76,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${rootClassName}`}
       >
-        <ThemeProvider theme={THEME}>
+        <Providers>
           {children}
           <Footer />
-        </ThemeProvider>
+        </Providers>
         <YandexMetrika />
       </body>
     </html>

--- a/src/components/GettingStartedSection/GettingStartedSection.tsx
+++ b/src/components/GettingStartedSection/GettingStartedSection.tsx
@@ -38,6 +38,8 @@ export type GettingStartedSectionBaseProps = {
   onCopyDemoUrl: (event: MouseEvent<HTMLButtonElement>) => void;
   docsTitle: string;
   docsLinks: DocsLink[];
+  localYdbExamplesTitle?: string;
+  localYdbExamplesLinks?: DocsLink[];
   selfHostedNodeBlock: ReactNode;
   dockerBlock: ReactNode;
   npmBlock: ReactNode;
@@ -65,6 +67,8 @@ export const GettingStartedSectionBase = ({
   onCopyDemoUrl,
   docsTitle,
   docsLinks,
+  localYdbExamplesTitle,
+  localYdbExamplesLinks = [],
   selfHostedNodeBlock,
   dockerBlock,
   npmBlock,
@@ -196,6 +200,30 @@ export const GettingStartedSectionBase = ({
             ))}
           </ul>
         </Card>
+        {localYdbExamplesLinks.length > 0 && (
+          <div style={{ marginTop: 24 }}>
+            <h3 className="section-title">{localYdbExamplesTitle}</h3>
+            <Card type="container">
+              <ul className="muted">
+                {localYdbExamplesLinks.map((link) => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      target={
+                        link.href.startsWith("http") ? "_blank" : undefined
+                      }
+                      rel={
+                        link.href.startsWith("http") ? "noopener" : undefined
+                      }
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        )}
       </div>
 
       <div

--- a/src/components/GettingStartedSection/locales.tsx
+++ b/src/components/GettingStartedSection/locales.tsx
@@ -23,6 +23,10 @@ export const gettingStartedSectionEnProps = (): Omit<
   const docsLinks: DocsLink[] = [
     { href: "/docs/", label: "Service diagrams (C4 + ER)" },
     { href: "https://ydb.tech/docs/en/", label: "YDB docs (overview)" },
+    {
+      href: "https://github.com/astandrik/local-ydb-toolkit",
+      label: "local-ydb-toolkit on GitHub",
+    },
     { href: "https://ydb.tech/docs/en/yql/reference/", label: "YQL reference" },
     {
       href: "https://ydb.tech/docs/en/concepts/vector_search",
@@ -35,6 +39,16 @@ export const gettingStartedSectionEnProps = (): Omit<
     {
       href: "https://www.npmjs.com/package/ydb-qdrant",
       label: "npm: ydb-qdrant",
+    },
+  ];
+  const localYdbExamplesLinks: DocsLink[] = [
+    {
+      href: "https://pets.ydb-qdrant.tech/",
+      label: "Codex Pets",
+    },
+    {
+      href: "https://gravity-ai.ydb-qdrant.tech/",
+      label: "Gravity AI",
     },
   ];
 
@@ -185,7 +199,15 @@ const client = await createYdbQdrantClient({
         >
           GitHub README
         </a>{" "}
-        for details.
+        for details. The related{" "}
+        <a
+          href="https://github.com/astandrik/local-ydb-toolkit"
+          target="_blank"
+          rel="noopener"
+        >
+          local-ydb-toolkit on GitHub
+        </a>{" "}
+        captures the reusable local YDB workflow.
       </p>
     </>
   );
@@ -210,6 +232,8 @@ const client = await createYdbQdrantClient({
     demoUrl,
     docsTitle: "Docs",
     docsLinks,
+    localYdbExamplesTitle: "Projects using local-ydb",
+    localYdbExamplesLinks,
     selfHostedNodeBlock,
     dockerBlock,
     npmBlock,
@@ -234,6 +258,10 @@ export const gettingStartedSectionRuProps = (): Omit<
       label: "Документация YDB (обзор)",
     },
     {
+      href: "https://github.com/astandrik/local-ydb-toolkit",
+      label: "local-ydb-toolkit на GitHub",
+    },
+    {
       href: "https://ydb.tech/docs/en/yql/reference/",
       label: "Справочник YQL",
     },
@@ -248,6 +276,16 @@ export const gettingStartedSectionRuProps = (): Omit<
     {
       href: "https://www.npmjs.com/package/ydb-qdrant",
       label: "npm: ydb-qdrant",
+    },
+  ];
+  const localYdbExamplesLinks: DocsLink[] = [
+    {
+      href: "https://pets.ydb-qdrant.tech/",
+      label: "Codex Pets",
+    },
+    {
+      href: "https://gravity-ai.ydb-qdrant.tech/",
+      label: "Gravity AI",
     },
   ];
 
@@ -403,7 +441,15 @@ const client = await createYdbQdrantClient({
         >
           GitHub README
         </a>{" "}
-        для подробностей.
+        для подробностей. Связанный{" "}
+        <a
+          href="https://github.com/astandrik/local-ydb-toolkit"
+          target="_blank"
+          rel="noopener"
+        >
+          local-ydb-toolkit на GitHub
+        </a>{" "}
+        фиксирует переиспользуемый workflow для локального YDB.
       </p>
     </>
   );
@@ -428,6 +474,8 @@ const client = await createYdbQdrantClient({
     demoUrl,
     docsTitle: "Документация",
     docsLinks,
+    localYdbExamplesTitle: "Проекты на local-ydb",
+    localYdbExamplesLinks,
     selfHostedNodeBlock,
     dockerBlock,
     npmBlock,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires local-ydb project references into the Getting Started UI and makes two supporting infrastructure changes. A `Providers` client component is extracted to properly isolate `ThemeProvider` from the server-rendered layout, and `turbopack.root` is set so Next.js/Turbopack can resolve local project paths.

- `GettingStartedSection` gains optional `localYdbExamplesTitle`/`localYdbExamplesLinks` props and renders a new card linking to live projects that use local-ydb; both EN and RU locales are updated with the `local-ydb-toolkit` GitHub link and two demo-project URLs.
- `next.config.ts` sets `turbopack.root` via `import.meta.url` so Turbopack resolves from the correct project root, and `.gitignore` adds `private/` to the sensitive-files block.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are additive content and lightweight refactors with no breaking surface.

The ThemeProvider extraction and turbopack config are clean and low-risk. The new localYdbExamples section in GettingStartedSection is additive, but the optional localYdbExamplesTitle prop can produce an empty h3 if links are passed without a title, and external links are missing noreferrer. The identical localYdbExamplesLinks array duplicated across both locale functions could silently drift. None of these are blockers, but the heading guard and the duplication are worth addressing before the next iteration.

src/components/GettingStartedSection/GettingStartedSection.tsx and src/components/GettingStartedSection/locales.tsx have the small issues noted above; the remaining files are straightforward.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Adds `private/` directory to the sensitive-files block — straightforward and correct. |
| next.config.ts | Adds Turbopack `root` pointing to the project directory via ESM `import.meta.url`; correct pattern for resolving local project references. |
| src/app/Providers.tsx | New `"use client"` wrapper that isolates `ThemeProvider` from the server-rendered layout; clean separation of concerns. |
| src/app/layout.tsx | Replaces inline `ThemeProvider` with the new `Providers` component; no logic changes, safe refactor. |
| src/components/GettingStartedSection/GettingStartedSection.tsx | Adds optional localYdbExamplesTitle/localYdbExamplesLinks props and renders a new card section; empty heading risk when title is omitted while links are present, and rel should include noreferrer. |
| src/components/GettingStartedSection/locales.tsx | Adds local-ydb-toolkit links to both EN and RU locale functions; localYdbExamplesLinks array is identical in both locales and should be a shared constant to avoid drift. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RootLayout - Server Component] --> B[Providers - Client Component]
    B --> C[ThemeProvider]
    C --> D[children]
    C --> E[Footer]
    A --> F[YandexMetrika]

    G[GettingStartedSectionBase] --> H{localYdbExamplesLinks.length > 0?}
    H -- Yes --> I[Render localYdbExamplesTitle h3]
    H -- Yes --> J[Render localYdbExamplesLinks Card]
    H -- No --> K[Skip section]

    L[locales EN] --> M[docsLinks + local-ydb-toolkit link]
    L --> N[localYdbExamplesLinks: Codex Pets, Gravity AI]
    O[locales RU] --> P[docsLinks + local-ydb-toolkit link]
    O --> Q[localYdbExamplesLinks: Codex Pets, Gravity AI - DUPLICATE]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/GettingStartedSection/locales.tsx`, line 18 ([link](https://github.com/astandrik/ydb-qdrant-ui/blob/0b50772be690e88f3c36d61d05aa68848c35448c/src/components/GettingStartedSection/locales.tsx#L18)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Identical `localYdbExamplesLinks` duplicated in both locale functions**

   The EN and RU locale functions define the exact same two-item `localYdbExamplesLinks` array. Since the `href` values are the same and the labels are not localised, extracting this to a module-level constant eliminates the duplication and prevents the two copies from drifting.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/GettingStartedSection/locales.tsx
   Line: 18

   Comment:
   **Identical `localYdbExamplesLinks` duplicated in both locale functions**

   The EN and RU locale functions define the exact same two-item `localYdbExamplesLinks` array. Since the `href` values are the same and the labels are not localised, extracting this to a module-level constant eliminates the duplication and prevents the two copies from drifting.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Fydb-qdrant-ui%22%20on%20the%20existing%20branch%20%22local-ydb%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22local-ydb%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FGettingStartedSection%2Flocales.tsx%0ALine%3A%2018%0A%0AComment%3A%0A**Identical%20%60localYdbExamplesLinks%60%20duplicated%20in%20both%20locale%20functions**%0A%0AThe%20EN%20and%20RU%20locale%20functions%20define%20the%20exact%20same%20two-item%20%60localYdbExamplesLinks%60%20array.%20Since%20the%20%60href%60%20values%20are%20the%20same%20and%20the%20labels%20are%20not%20localised%2C%20extracting%20this%20to%20a%20module-level%20constant%20eliminates%20the%20duplication%20and%20prevents%20the%20two%20copies%20from%20drifting.%0A%0A%60%60%60suggestion%0Aconst%20sharedLocalYdbExamplesLinks%3A%20DocsLink%5B%5D%20%3D%20%5B%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fpets.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Codex%20Pets%22%20%7D%2C%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fgravity-ai.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Gravity%20AI%22%20%7D%2C%0A%5D%3B%0A%0Aexport%20const%20gettingStartedSectionEnProps%20%3D%20%28%29%3A%20Omit%3C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FGettingStartedSection%2Flocales.tsx%0ALine%3A%2018%0A%0AComment%3A%0A**Identical%20%60localYdbExamplesLinks%60%20duplicated%20in%20both%20locale%20functions**%0A%0AThe%20EN%20and%20RU%20locale%20functions%20define%20the%20exact%20same%20two-item%20%60localYdbExamplesLinks%60%20array.%20Since%20the%20%60href%60%20values%20are%20the%20same%20and%20the%20labels%20are%20not%20localised%2C%20extracting%20this%20to%20a%20module-level%20constant%20eliminates%20the%20duplication%20and%20prevents%20the%20two%20copies%20from%20drifting.%0A%0A%60%60%60suggestion%0Aconst%20sharedLocalYdbExamplesLinks%3A%20DocsLink%5B%5D%20%3D%20%5B%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fpets.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Codex%20Pets%22%20%7D%2C%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fgravity-ai.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Gravity%20AI%22%20%7D%2C%0A%5D%3B%0A%0Aexport%20const%20gettingStartedSectionEnProps%20%3D%20%28%29%3A%20Omit%3C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=astandrik%2Fydb-qdrant-ui&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Fydb-qdrant-ui%22%20on%20the%20existing%20branch%20%22local-ydb%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22local-ydb%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fcomponents%2FGettingStartedSection%2FGettingStartedSection.tsx%3A203-204%0A**Empty%20heading%20when%20title%20is%20omitted**%0A%0A%60localYdbExamplesTitle%60%20is%20optional%20and%20has%20no%20default%2C%20so%20if%20a%20caller%20passes%20%60localYdbExamplesLinks%60%20with%20items%20but%20omits%20%60localYdbExamplesTitle%60%2C%20the%20guard%20%60localYdbExamplesLinks.length%20%3E%200%60%20is%20satisfied%20and%20an%20empty%20%60%3Ch3%20className%3D%22section-title%22%3E%3C%2Fh3%3E%60%20is%20rendered.%20Either%20require%20the%20title%20whenever%20links%20are%20provided%20%28e.g.%2C%20make%20both%20required%20together%20or%20use%20a%20single%20object%20prop%29%20or%20add%20a%20%60localYdbExamplesTitle%20%26%26%60%20check%20before%20rendering%20the%20heading.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fcomponents%2FGettingStartedSection%2FGettingStartedSection.tsx%3A215-217%0A**Missing%20%60noreferrer%60%20on%20external%20link%20%60rel%60**%0A%0AUsing%20only%20%60rel%3D%22noopener%22%60%20on%20external%20links%20doesn't%20prevent%20the%20browser%20from%20sending%20the%20%60Referer%60%20header%20to%20the%20destination.%20The%20conventional%20pairing%20%60noopener%20noreferrer%60%20is%20both%20the%20security%20and%20privacy%20best%20practice%20for%20%60target%3D%22_blank%22%60%20links.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rel%3D%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20link.href.startsWith%28%22http%22%29%20%3F%20%22noopener%20noreferrer%22%20%3A%20undefined%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fcomponents%2FGettingStartedSection%2Flocales.tsx%3A18%0A**Identical%20%60localYdbExamplesLinks%60%20duplicated%20in%20both%20locale%20functions**%0A%0AThe%20EN%20and%20RU%20locale%20functions%20define%20the%20exact%20same%20two-item%20%60localYdbExamplesLinks%60%20array.%20Since%20the%20%60href%60%20values%20are%20the%20same%20and%20the%20labels%20are%20not%20localised%2C%20extracting%20this%20to%20a%20module-level%20constant%20eliminates%20the%20duplication%20and%20prevents%20the%20two%20copies%20from%20drifting.%0A%0A%60%60%60suggestion%0Aconst%20sharedLocalYdbExamplesLinks%3A%20DocsLink%5B%5D%20%3D%20%5B%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fpets.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Codex%20Pets%22%20%7D%2C%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fgravity-ai.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Gravity%20AI%22%20%7D%2C%0A%5D%3B%0A%0Aexport%20const%20gettingStartedSectionEnProps%20%3D%20%28%29%3A%20Omit%3C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fcomponents%2FGettingStartedSection%2FGettingStartedSection.tsx%3A203-204%0A**Empty%20heading%20when%20title%20is%20omitted**%0A%0A%60localYdbExamplesTitle%60%20is%20optional%20and%20has%20no%20default%2C%20so%20if%20a%20caller%20passes%20%60localYdbExamplesLinks%60%20with%20items%20but%20omits%20%60localYdbExamplesTitle%60%2C%20the%20guard%20%60localYdbExamplesLinks.length%20%3E%200%60%20is%20satisfied%20and%20an%20empty%20%60%3Ch3%20className%3D%22section-title%22%3E%3C%2Fh3%3E%60%20is%20rendered.%20Either%20require%20the%20title%20whenever%20links%20are%20provided%20%28e.g.%2C%20make%20both%20required%20together%20or%20use%20a%20single%20object%20prop%29%20or%20add%20a%20%60localYdbExamplesTitle%20%26%26%60%20check%20before%20rendering%20the%20heading.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fcomponents%2FGettingStartedSection%2FGettingStartedSection.tsx%3A215-217%0A**Missing%20%60noreferrer%60%20on%20external%20link%20%60rel%60**%0A%0AUsing%20only%20%60rel%3D%22noopener%22%60%20on%20external%20links%20doesn't%20prevent%20the%20browser%20from%20sending%20the%20%60Referer%60%20header%20to%20the%20destination.%20The%20conventional%20pairing%20%60noopener%20noreferrer%60%20is%20both%20the%20security%20and%20privacy%20best%20practice%20for%20%60target%3D%22_blank%22%60%20links.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rel%3D%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20link.href.startsWith%28%22http%22%29%20%3F%20%22noopener%20noreferrer%22%20%3A%20undefined%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fcomponents%2FGettingStartedSection%2Flocales.tsx%3A18%0A**Identical%20%60localYdbExamplesLinks%60%20duplicated%20in%20both%20locale%20functions**%0A%0AThe%20EN%20and%20RU%20locale%20functions%20define%20the%20exact%20same%20two-item%20%60localYdbExamplesLinks%60%20array.%20Since%20the%20%60href%60%20values%20are%20the%20same%20and%20the%20labels%20are%20not%20localised%2C%20extracting%20this%20to%20a%20module-level%20constant%20eliminates%20the%20duplication%20and%20prevents%20the%20two%20copies%20from%20drifting.%0A%0A%60%60%60suggestion%0Aconst%20sharedLocalYdbExamplesLinks%3A%20DocsLink%5B%5D%20%3D%20%5B%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fpets.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Codex%20Pets%22%20%7D%2C%0A%20%20%7B%20href%3A%20%22https%3A%2F%2Fgravity-ai.ydb-qdrant.tech%2F%22%2C%20label%3A%20%22Gravity%20AI%22%20%7D%2C%0A%5D%3B%0A%0Aexport%20const%20gettingStartedSectionEnProps%20%3D%20%28%29%3A%20Omit%3C%0A%60%60%60%0A%0A&repo=astandrik%2Fydb-qdrant-ui&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/components/GettingStartedSection/GettingStartedSection.tsx:203-204
**Empty heading when title is omitted**

`localYdbExamplesTitle` is optional and has no default, so if a caller passes `localYdbExamplesLinks` with items but omits `localYdbExamplesTitle`, the guard `localYdbExamplesLinks.length > 0` is satisfied and an empty `<h3 className="section-title"></h3>` is rendered. Either require the title whenever links are provided (e.g., make both required together or use a single object prop) or add a `localYdbExamplesTitle &&` check before rendering the heading.

### Issue 2 of 3
src/components/GettingStartedSection/GettingStartedSection.tsx:215-217
**Missing `noreferrer` on external link `rel`**

Using only `rel="noopener"` on external links doesn't prevent the browser from sending the `Referer` header to the destination. The conventional pairing `noopener noreferrer` is both the security and privacy best practice for `target="_blank"` links.

```suggestion
                      rel={
                        link.href.startsWith("http") ? "noopener noreferrer" : undefined
                      }
```

### Issue 3 of 3
src/components/GettingStartedSection/locales.tsx:18
**Identical `localYdbExamplesLinks` duplicated in both locale functions**

The EN and RU locale functions define the exact same two-item `localYdbExamplesLinks` array. Since the `href` values are the same and the labels are not localised, extracting this to a module-level constant eliminates the duplication and prevents the two copies from drifting.

```suggestion
const sharedLocalYdbExamplesLinks: DocsLink[] = [
  { href: "https://pets.ydb-qdrant.tech/", label: "Codex Pets" },
  { href: "https://gravity-ai.ydb-qdrant.tech/", label: "Gravity AI" },
];

export const gettingStartedSectionEnProps = (): Omit<
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add local-ydb project references"](https://github.com/astandrik/ydb-qdrant-ui/commit/0b50772be690e88f3c36d61d05aa68848c35448c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719406)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->