### PR TITLE
Add Code Indexer public site

### DIFF
--- a/src/app/code-indexer/admin/page.tsx
+++ b/src/app/code-indexer/admin/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { CodeIndexerAdminDashboard } from "@/components/CodeIndexer/CodeIndexerAdminDashboard";
+
+export const metadata: Metadata = {
+  title: "Code Indexer Admin",
+  description:
+    "Read-only operational dashboard for hosted YDB Qdrant Code Indexer repositories and jobs.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function CodeIndexerAdminPage() {
+  return <CodeIndexerAdminDashboard />;
+}

--- a/src/app/code-indexer/dashboard/page.tsx
+++ b/src/app/code-indexer/dashboard/page.tsx
@@ -5,6 +5,10 @@ export const metadata: Metadata = {
   title: "Code Indexer Dashboard",
   description:
     "Manage indexed repositories and hosted MCP tokens for YDB Qdrant Code Indexer.",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function CodeIndexerDashboardPage() {

--- a/src/app/code-indexer/dashboard/page.tsx
+++ b/src/app/code-indexer/dashboard/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { CodeIndexerDashboard } from "@/components/CodeIndexer/CodeIndexerDashboard";
+
+export const metadata: Metadata = {
+  title: "Code Indexer Dashboard",
+  description:
+    "Manage indexed repositories and hosted MCP tokens for YDB Qdrant Code Indexer.",
+};
+
+export default function CodeIndexerDashboardPage() {
+  return <CodeIndexerDashboard />;
+}

--- a/src/app/code-indexer/page.tsx
+++ b/src/app/code-indexer/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { CodeIndexerLanding } from "@/components/CodeIndexer/CodeIndexerLanding";
+
+export const metadata: Metadata = {
+  title: "YDB Qdrant Code Indexer",
+  description:
+    "Install a GitHub App, index repositories into YDB-backed Qdrant-compatible storage, and connect coding agents through hosted MCP.",
+};
+
+export default function CodeIndexerPage() {
+  return <CodeIndexerLanding />;
+}

--- a/src/app/code-indexer/page.tsx
+++ b/src/app/code-indexer/page.tsx
@@ -5,6 +5,32 @@ export const metadata: Metadata = {
   title: "YDB Qdrant Code Indexer",
   description:
     "Install a GitHub App, index repositories into YDB-backed Qdrant-compatible storage, and connect coding agents through hosted MCP.",
+  alternates: {
+    canonical: "/code-indexer/",
+  },
+  openGraph: {
+    title: "YDB Qdrant Code Indexer",
+    description:
+      "Install a GitHub App, index repositories into YDB-backed Qdrant-compatible storage, and connect coding agents through hosted MCP.",
+    type: "website",
+    url: "/code-indexer/",
+    images: [
+      {
+        url: "/assets/preview.png",
+        width: 1024,
+        height: 1024,
+        type: "image/png",
+        alt: "YDB Qdrant Code Indexer dashboard and agent memory preview",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "YDB Qdrant Code Indexer",
+    description:
+      "Index GitHub repositories into YDB-backed Qdrant-compatible vector storage for coding agents.",
+    images: ["/assets/preview.png"],
+  },
 };
 
 export default function CodeIndexerPage() {

--- a/src/app/code-indexer/privacy/page.tsx
+++ b/src/app/code-indexer/privacy/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Code Indexer Privacy",
   description:
     "Stored data and deletion behavior for YDB Qdrant Code Indexer.",
+  alternates: {
+    canonical: "/code-indexer/privacy/",
+  },
 };
 
 export default function CodeIndexerPrivacyPage() {

--- a/src/app/code-indexer/privacy/page.tsx
+++ b/src/app/code-indexer/privacy/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { CodeIndexerInfoPage } from "@/components/CodeIndexer/CodeIndexerInfoPage";
+
+export const metadata: Metadata = {
+  title: "Code Indexer Privacy",
+  description:
+    "Stored data and deletion behavior for YDB Qdrant Code Indexer.",
+};
+
+export default function CodeIndexerPrivacyPage() {
+  return (
+    <CodeIndexerInfoPage
+      eyebrow="Privacy"
+      title="Code Indexer privacy"
+      lead="YDB Qdrant Code Indexer stores the minimum data needed to index installed repositories and serve hosted MCP search."
+      sections={[
+        {
+          items: [
+            "GitHub account, installation, and repository metadata needed to show access and indexing status.",
+            "Code snippets selected by repository permissions and repository indexing configuration.",
+            "Embedding vectors generated from indexed snippets and stored in YDB-backed Qdrant-compatible collections.",
+            "MCP/API tokens as hashes only. Plaintext tokens are shown once when created.",
+            "Usage counters and audit logs for quota enforcement, abuse prevention, and operational debugging.",
+          ],
+          title: "Stored data",
+        },
+        {
+          items: [
+            "Uninstalling the GitHub App or removing a repository deletes indexed collections for removed repositories.",
+            "The dashboard delete-data action removes sessions, MCP/API tokens, GitHub user data, linked installation rows, repository rows, and indexed repository data where the user owns the eligible linked data.",
+            "Revoking an MCP token immediately prevents future hosted MCP searches with that token.",
+          ],
+          title: "Deletion behavior",
+        },
+      ]}
+    />
+  );
+}

--- a/src/app/code-indexer/status/page.tsx
+++ b/src/app/code-indexer/status/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import { CodeIndexerInfoPage } from "@/components/CodeIndexer/CodeIndexerInfoPage";
+
+export const metadata: Metadata = {
+  title: "Code Indexer Status",
+  description:
+    "Public endpoint status links for YDB Qdrant Code Indexer.",
+};
+
+export default function CodeIndexerStatusPage() {
+  return (
+    <CodeIndexerInfoPage
+      eyebrow="Status"
+      title="Code Indexer status"
+      lead="Public beta traffic uses the hosted backend at code-indexer.ydb-qdrant.tech."
+      actions={[
+        {
+          href: "https://code-indexer.ydb-qdrant.tech/health",
+          label: "Open health endpoint",
+        },
+      ]}
+      sections={[
+        {
+          items: [
+            "GET https://code-indexer.ydb-qdrant.tech/health",
+            "POST https://code-indexer.ydb-qdrant.tech/github/webhook",
+            "GET https://code-indexer.ydb-qdrant.tech/github/oauth/start",
+            "GET https://code-indexer.ydb-qdrant.tech/github/oauth/callback",
+            "GET/POST https://code-indexer.ydb-qdrant.tech/mcp",
+            "GET/POST/DELETE https://code-indexer.ydb-qdrant.tech/api/*",
+          ],
+          title: "Public endpoints",
+        },
+        {
+          items: [
+            "The health endpoint is the current public readiness signal.",
+            "Dashboard pages are statically hosted on ydb-qdrant.tech and call the backend over HTTPS.",
+          ],
+          title: "Operational notes",
+        },
+      ]}
+    />
+  );
+}

--- a/src/app/code-indexer/status/page.tsx
+++ b/src/app/code-indexer/status/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Code Indexer Status",
   description:
     "Public endpoint status links for YDB Qdrant Code Indexer.",
+  alternates: {
+    canonical: "/code-indexer/status/",
+  },
 };
 
 export default function CodeIndexerStatusPage() {

--- a/src/app/code-indexer/support/page.tsx
+++ b/src/app/code-indexer/support/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { CodeIndexerInfoPage } from "@/components/CodeIndexer/CodeIndexerInfoPage";
+
+export const metadata: Metadata = {
+  title: "Code Indexer Support",
+  description:
+    "Support links for YDB Qdrant Code Indexer public beta users.",
+};
+
+export default function CodeIndexerSupportPage() {
+  return (
+    <CodeIndexerInfoPage
+      eyebrow="Support"
+      title="Code Indexer support"
+      lead="For public beta support, use GitHub Issues in the ydb-qdrant repository."
+      actions={[
+        {
+          href: "https://github.com/astandrik/ydb-qdrant/issues",
+          label: "Open GitHub Issues",
+        },
+        {
+          href: "https://github.com/astandrik/ydb-qdrant",
+          label: "View repository",
+        },
+      ]}
+      sections={[
+        {
+          items: [
+            "Installation and OAuth callback problems.",
+            "Repository indexing failures or stale dashboard status.",
+            "Hosted MCP authentication, token revocation, and search behavior.",
+            "Privacy or data deletion requests that need manual follow-up.",
+          ],
+          title: "What to report",
+        },
+      ]}
+    />
+  );
+}

--- a/src/app/code-indexer/support/page.tsx
+++ b/src/app/code-indexer/support/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Code Indexer Support",
   description:
     "Support links for YDB Qdrant Code Indexer public beta users.",
+  alternates: {
+    canonical: "/code-indexer/support/",
+  },
 };
 
 export default function CodeIndexerSupportPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,14 +28,14 @@ export const metadata: Metadata = {
   title: "Qdrant API on YDB",
   description:
     "Qdrant-compatible vector search API on YDB. Exact top-k search over a global one-table layout for HTTP, Node.js library, and million-vector collection scenarios.",
-  metadataBase: new URL("http://ydb-qdrant.tech"),
+  metadataBase: new URL("https://ydb-qdrant.tech"),
   authors: [{ name: "ydb-qdrant" }],
   openGraph: {
     title: "Qdrant API on YDB",
     description:
       "Qdrant-compatible vector search on YDB with exact top-k search, HTTP server mode, Node.js library mode, and million-vector collections.",
     type: "website",
-    url: "http://ydb-qdrant.tech/",
+    url: "https://ydb-qdrant.tech/",
     images: [
       {
         url: "/assets/preview.png",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import PlansSection from "@/components/PlansSection";
 import GettingStartedSection from "@/components/GettingStartedSection";
 import ApiAtAGlanceSection from "@/components/ApiAtAGlanceSection";
 import VectorDimensionsSection from "@/components/VectorDimensionsSection";
+import { CodeIndexerHomePromo } from "@/components/CodeIndexer/CodeIndexerLanding";
 import { createCopyToClipboardHandler } from "@/shared/utils/copyToClipboard";
 import { trackGoal } from "@/shared/utils/metricsManager";
 import {
@@ -136,6 +137,7 @@ function HomeContent() {
             handleCopy(DEMO_URL, e)
           }
         />
+        <CodeIndexerHomePromo />
         <WhySection />
         <WhereSection />
         <PlansSection />

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/code-indexer/dashboard/"],
+      disallow: ["/code-indexer/dashboard/", "/code-indexer/admin/"],
     },
     sitemap: `${SITE_URL}/sitemap.xml`,
     host: SITE_URL,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://ydb-qdrant.tech";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/code-indexer/dashboard/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/ru/page.tsx
+++ b/src/app/ru/page.tsx
@@ -15,6 +15,10 @@ import { PlansSectionRu } from "@/components/PlansSection";
 import { ApiAtAGlanceSectionRu } from "@/components/ApiAtAGlanceSection";
 import { VectorDimensionsSectionRu } from "@/components/VectorDimensionsSection";
 import { GettingStartedSectionRu } from "@/components/GettingStartedSection";
+import {
+  CodeIndexerHomePromo,
+  codeIndexerHomePromoRu,
+} from "@/components/CodeIndexer/CodeIndexerLanding";
 import { createCopyToClipboardHandler } from "@/shared/utils/copyToClipboard";
 import { trackGoal } from "@/shared/utils/metricsManager";
 import {
@@ -138,6 +142,7 @@ function HomeRuContent() {
             handleCopy(DEMO_URL, e)
           }
         />
+        <CodeIndexerHomePromo content={codeIndexerHomePromoRu} />
 
         <WhySectionRu />
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://ydb-qdrant.tech";
+
+export const dynamic = "force-static";
+
+const pages = [
+  { path: "/", priority: 1 },
+  { path: "/en/", priority: 0.9 },
+  { path: "/ru/", priority: 0.9 },
+  { path: "/docs/", priority: 0.8 },
+  { path: "/ru/docs/", priority: 0.7 },
+  { path: "/code-indexer/", priority: 0.9 },
+  { path: "/code-indexer/privacy/", priority: 0.5 },
+  { path: "/code-indexer/support/", priority: 0.5 },
+  { path: "/code-indexer/status/", priority: 0.5 },
+] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return pages.map(({ path, priority }) => ({
+    url: `${SITE_URL}${path}`,
+    changeFrequency: "weekly",
+    priority,
+  }));
+}

--- a/src/components/CodeIndexer/CodeIndexer.scss
+++ b/src/components/CodeIndexer/CodeIndexer.scss
@@ -463,3 +463,41 @@
     line-height: 1.6;
   }
 }
+
+.code-indexer-info {
+  max-width: 960px;
+
+  &__hero,
+  &__section {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.045);
+  }
+
+  &__hero {
+    margin-bottom: var(--spacing-lg);
+    padding: var(--spacing-2xl);
+  }
+
+  &__section {
+    margin-top: var(--spacing-lg);
+    padding: var(--spacing-2xl);
+
+    h2 {
+      margin-bottom: var(--spacing-lg);
+    }
+
+    ul {
+      display: grid;
+      gap: var(--spacing-md);
+      margin: 0;
+      padding-left: var(--spacing-xl);
+      color: rgba(255, 255, 255, 0.72);
+      line-height: 1.65;
+    }
+
+    li {
+      overflow-wrap: anywhere;
+    }
+  }
+}

--- a/src/components/CodeIndexer/CodeIndexer.scss
+++ b/src/components/CodeIndexer/CodeIndexer.scss
@@ -471,6 +471,89 @@
   }
 }
 
+.code-indexer-progress {
+  display: grid;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  border: 1px solid rgba(155, 229, 255, 0.18);
+  border-radius: var(--radius-md);
+  background: rgba(155, 229, 255, 0.06);
+
+  &__heading {
+    display: grid;
+    gap: var(--spacing-xs);
+
+    @include sm {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+    }
+
+    strong {
+      overflow-wrap: anywhere;
+      color: rgba(255, 255, 255, 0.88);
+      text-transform: capitalize;
+    }
+
+    span {
+      overflow-wrap: anywhere;
+      color: rgba(255, 255, 255, 0.48);
+      font-family: var(--font-mono);
+      font-size: 11px;
+    }
+  }
+
+  &__bar {
+    width: 100%;
+    height: 7px;
+    overflow: hidden;
+    border-radius: var(--radius-full);
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  &__bar-fill {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #9be5ff, #ffbe5c);
+    transition: width 180ms ease;
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs) var(--spacing-md);
+    color: rgba(255, 255, 255, 0.64);
+    font-size: 12px;
+  }
+
+  &__path,
+  &__message,
+  &__warning,
+  &__error {
+    margin: 0;
+    overflow-wrap: anywhere;
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  &__path {
+    color: rgba(255, 255, 255, 0.72);
+    font-family: var(--font-mono);
+  }
+
+  &__message {
+    color: rgba(255, 255, 255, 0.58);
+  }
+
+  &__warning {
+    color: #ffca7a;
+  }
+
+  &__error {
+    color: #ff9a9b;
+  }
+}
+
 .code-indexer-info {
   max-width: 960px;
 

--- a/src/components/CodeIndexer/CodeIndexer.scss
+++ b/src/components/CodeIndexer/CodeIndexer.scss
@@ -295,6 +295,7 @@
 
   &__select,
   &__config,
+  &__agent-prompt pre,
   &__created-token code {
     width: 100%;
     border: 1px solid rgba(255, 255, 255, 0.14);
@@ -368,6 +369,19 @@
       background: rgba(255, 77, 79, 0.12);
       color: #ff9a9b;
     }
+
+    &--running,
+    &--pending,
+    &--queued,
+    &--indexing {
+      background: rgba(155, 229, 255, 0.1);
+      color: #9be5ff;
+    }
+
+    &--completed {
+      background: rgba(100, 210, 155, 0.12);
+      color: #83e0b0;
+    }
   }
 
   &__repo-meta {
@@ -390,6 +404,11 @@
       color: rgba(255, 255, 255, 0.82);
       font-size: 14px;
     }
+  }
+
+  &__job-list {
+    display: grid;
+    gap: var(--spacing-sm);
   }
 
   &__empty {
@@ -469,6 +488,194 @@
     font-size: 12px;
     line-height: 1.6;
   }
+
+  &__agent-prompt {
+    display: grid;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-lg);
+    padding-top: var(--spacing-lg);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+
+    h3 {
+      margin-bottom: 0;
+      font-size: 16px;
+    }
+
+    p {
+      margin-bottom: 0;
+      color: rgba(255, 255, 255, 0.62);
+      line-height: 1.55;
+    }
+
+    pre {
+      margin: var(--spacing-xs) 0;
+      padding: var(--spacing-md);
+      overflow: auto;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+    }
+  }
+}
+
+.code-indexer-admin {
+  max-width: 1480px;
+
+  h1 {
+    font-size: clamp(36px, 5vw, 56px);
+    line-height: 1;
+  }
+
+  &__header {
+    align-items: center;
+  }
+
+  &__summary {
+    display: grid;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+
+    @include sm {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @include lg {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    div {
+      min-height: 92px;
+      padding: var(--spacing-lg);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: var(--radius-lg);
+      background: rgba(255, 255, 255, 0.045);
+    }
+
+    span,
+    strong {
+      display: block;
+    }
+
+    span {
+      color: rgba(255, 255, 255, 0.52);
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    strong {
+      margin-top: var(--spacing-sm);
+      color: rgba(255, 255, 255, 0.9);
+      font-size: 28px;
+      line-height: 1;
+    }
+  }
+
+  &__filters {
+    display: grid;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+
+    @include md {
+      grid-template-columns: minmax(260px, 1fr) 180px 180px;
+    }
+  }
+
+  &__status-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-lg);
+
+    span {
+      padding: var(--spacing-xs) var(--spacing-sm);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: var(--radius-full);
+      background: rgba(0, 0, 0, 0.16);
+      color: rgba(255, 255, 255, 0.62);
+      font-size: 12px;
+    }
+  }
+
+  &__layout {
+    display: grid;
+    gap: var(--spacing-lg);
+
+    @include xl {
+      grid-template-columns: minmax(0, 1.6fr) minmax(360px, 0.75fr);
+      align-items: start;
+    }
+  }
+
+  &__table-wrap {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  &__table {
+    width: 100%;
+    min-width: 980px;
+    border-collapse: collapse;
+
+    th,
+    td {
+      padding: var(--spacing-md);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      color: rgba(155, 229, 255, 0.82);
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    td {
+      color: rgba(255, 255, 255, 0.76);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    strong,
+    span {
+      display: block;
+      overflow-wrap: anywhere;
+    }
+
+    strong {
+      color: rgba(255, 255, 255, 0.88);
+    }
+
+    span {
+      margin-top: var(--spacing-xs);
+      color: rgba(255, 255, 255, 0.48);
+      font-family: var(--font-mono);
+      font-size: 11px;
+    }
+  }
+
+  &__job-stack {
+    display: grid;
+    gap: var(--spacing-xs);
+  }
+
+  &__jobs {
+    display: grid;
+    gap: var(--spacing-md);
+    max-height: 980px;
+    overflow-y: auto;
+    padding-right: var(--spacing-xs);
+
+    .code-indexer-progress,
+    .code-indexer-progress__heading {
+      min-width: 0;
+    }
+
+    .code-indexer-progress__heading {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
 }
 
 .code-indexer-progress {
@@ -491,7 +698,6 @@
     strong {
       overflow-wrap: anywhere;
       color: rgba(255, 255, 255, 0.88);
-      text-transform: capitalize;
     }
 
     span {

--- a/src/components/CodeIndexer/CodeIndexer.scss
+++ b/src/components/CodeIndexer/CodeIndexer.scss
@@ -398,6 +398,13 @@
     line-height: 1.55;
   }
 
+  &__polling {
+    margin: 0;
+    color: rgba(155, 229, 255, 0.78);
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
   &__token-form {
     display: grid;
     gap: var(--spacing-md);

--- a/src/components/CodeIndexer/CodeIndexer.scss
+++ b/src/components/CodeIndexer/CodeIndexer.scss
@@ -1,0 +1,465 @@
+@use "@/styles/mixins" as *;
+
+.code-indexer {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: var(--spacing-3xl) var(--spacing-lg);
+
+  @include sm {
+    padding: var(--spacing-5xl) var(--spacing-xl);
+  }
+
+  h1,
+  h2,
+  h3,
+  p {
+    margin-top: 0;
+  }
+
+  h1 {
+    max-width: 760px;
+    margin-bottom: var(--spacing-lg);
+    font-size: clamp(40px, 7vw, 76px);
+    line-height: 0.95;
+  }
+
+  h2 {
+    margin-bottom: var(--spacing-md);
+    font-size: 26px;
+    line-height: 1.15;
+  }
+
+  h3 {
+    margin-bottom: var(--spacing-sm);
+    font-size: 17px;
+  }
+
+  &__hero {
+    display: grid;
+    min-height: min(760px, calc(100vh - 120px));
+    align-items: center;
+    gap: var(--spacing-4xl);
+
+    @include lg {
+      grid-template-columns: minmax(0, 1fr) 420px;
+    }
+  }
+
+  &__hero-copy {
+    position: relative;
+    z-index: 1;
+  }
+
+  &__hero-visual {
+    position: relative;
+    min-height: 360px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    background: #0d151c;
+  }
+
+  &__hero-image {
+    width: 100%;
+    height: 100%;
+    min-height: 360px;
+    object-fit: cover;
+    opacity: 0.72;
+  }
+
+  &__terminal {
+    position: absolute;
+    right: var(--spacing-lg);
+    bottom: var(--spacing-lg);
+    left: var(--spacing-lg);
+    overflow: hidden;
+    border: 1px solid rgba(155, 229, 255, 0.24);
+    border-radius: var(--radius-lg);
+    background: rgba(7, 11, 15, 0.88);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+
+    pre {
+      margin: 0;
+      padding: var(--spacing-lg);
+      overflow-x: auto;
+      color: #e9f7ff;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+  }
+
+  &__terminal-bar {
+    display: flex;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+    span {
+      width: 9px;
+      height: 9px;
+      border-radius: var(--radius-full);
+      background: rgba(255, 255, 255, 0.28);
+    }
+  }
+
+  &__eyebrow {
+    margin-bottom: var(--spacing-md);
+    color: #9be5ff;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
+
+  &__lead {
+    max-width: 680px;
+    margin-bottom: var(--spacing-2xl);
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 18px;
+    line-height: 1.65;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+  }
+
+  &__section {
+    margin-top: var(--spacing-6xl);
+  }
+
+  &__section-heading {
+    max-width: 700px;
+    margin-bottom: var(--spacing-2xl);
+  }
+
+  &__feature-grid {
+    display: grid;
+    gap: var(--spacing-lg);
+
+    @include md {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    &--compact {
+      @include md {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+  }
+
+  &__feature {
+    min-height: 184px;
+    padding: var(--spacing-2xl);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.04);
+
+    svg {
+      margin-bottom: var(--spacing-lg);
+      color: var(--acc);
+    }
+
+    p {
+      margin-bottom: 0;
+      color: rgba(255, 255, 255, 0.62);
+      line-height: 1.6;
+    }
+  }
+}
+
+.code-indexer-promo {
+  display: grid;
+  gap: var(--spacing-lg);
+  align-items: center;
+  margin: var(--spacing-4xl) 0;
+  padding: var(--spacing-2xl);
+  border: 1px solid rgba(155, 229, 255, 0.2);
+  border-radius: var(--radius-lg);
+  background: rgba(11, 22, 29, 0.78);
+
+  @include md {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  h2 {
+    margin: 0 0 var(--spacing-sm);
+    font-size: 24px;
+  }
+
+  p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.65);
+    line-height: 1.55;
+  }
+
+  &__eyebrow {
+    margin-bottom: var(--spacing-xs) !important;
+    color: #9be5ff !important;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+}
+
+.code-indexer-dashboard {
+  max-width: 1240px;
+
+  &__header,
+  &__panel {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.045);
+  }
+
+  &__header {
+    display: grid;
+    gap: var(--spacing-lg);
+    margin-bottom: var(--spacing-2xl);
+    padding: var(--spacing-2xl);
+
+    @include md {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+  }
+
+  &__header-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+    align-items: flex-start;
+    justify-content: flex-start;
+
+    @include md {
+      justify-content: flex-end;
+    }
+  }
+
+  &__grid {
+    display: grid;
+    gap: var(--spacing-lg);
+
+    @include lg {
+      grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.8fr);
+      align-items: start;
+    }
+  }
+
+  &__side {
+    display: grid;
+    gap: var(--spacing-lg);
+  }
+
+  &__panel {
+    padding: var(--spacing-2xl);
+
+    &--danger {
+      border-color: rgba(255, 77, 79, 0.32);
+
+      p {
+        color: rgba(255, 255, 255, 0.62);
+        line-height: 1.55;
+      }
+    }
+  }
+
+  &__panel-heading {
+    display: grid;
+    gap: var(--spacing-md);
+    align-items: start;
+    margin-bottom: var(--spacing-xl);
+
+    @include sm {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    h2 {
+      margin-bottom: 0;
+    }
+  }
+
+  &__notice {
+    margin-bottom: var(--spacing-lg);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border: 1px solid rgba(155, 229, 255, 0.24);
+    border-radius: var(--radius-md);
+    background: rgba(155, 229, 255, 0.08);
+
+    &--error {
+      border-color: rgba(255, 77, 79, 0.35);
+      background: rgba(255, 77, 79, 0.08);
+    }
+  }
+
+  &__select,
+  &__config,
+  &__created-token code {
+    width: 100%;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: var(--radius-md);
+    background: rgba(0, 0, 0, 0.28);
+    color: var(--fg);
+  }
+
+  &__select {
+    min-height: 40px;
+    padding: 0 var(--spacing-md);
+  }
+
+  &__repo-list,
+  &__token-list {
+    display: grid;
+    gap: var(--spacing-md);
+  }
+
+  &__repo {
+    display: grid;
+    gap: var(--spacing-lg);
+    padding: var(--spacing-lg);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    background: rgba(0, 0, 0, 0.16);
+  }
+
+  &__repo-main {
+    display: grid;
+    gap: var(--spacing-md);
+
+    @include sm {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: start;
+    }
+
+    h3 {
+      margin-bottom: var(--spacing-xs);
+      overflow-wrap: anywhere;
+    }
+
+    p {
+      margin-bottom: 0;
+      color: rgba(255, 255, 255, 0.58);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+  }
+
+  &__status {
+    display: inline-flex;
+    width: max-content;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: 5px 9px;
+    border-radius: var(--radius-full);
+    background: rgba(155, 229, 255, 0.1);
+    color: #9be5ff;
+    font-size: 12px;
+    font-weight: 700;
+
+    &--ready {
+      background: rgba(100, 210, 155, 0.12);
+      color: #83e0b0;
+    }
+
+    &--failed,
+    &--deleted {
+      background: rgba(255, 77, 79, 0.12);
+      color: #ff9a9b;
+    }
+  }
+
+  &__repo-meta {
+    display: grid;
+    gap: var(--spacing-md);
+    margin: 0;
+
+    @include sm {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    dt {
+      color: rgba(255, 255, 255, 0.46);
+      font-size: 12px;
+    }
+
+    dd {
+      margin: var(--spacing-xs) 0 0;
+      overflow-wrap: anywhere;
+      color: rgba(255, 255, 255, 0.82);
+      font-size: 14px;
+    }
+  }
+
+  &__empty {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.58);
+    line-height: 1.55;
+  }
+
+  &__token-form {
+    display: grid;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+
+    @include sm {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+  }
+
+  &__created-token {
+    display: grid;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    padding: var(--spacing-lg);
+    border: 1px solid rgba(255, 190, 92, 0.28);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 190, 92, 0.08);
+
+    p {
+      margin-bottom: 0;
+      font-weight: 700;
+    }
+
+    code {
+      display: block;
+      padding: var(--spacing-md);
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 12px;
+    }
+  }
+
+  &__token {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--spacing-md);
+    align-items: center;
+    padding: var(--spacing-md);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-md);
+
+    strong,
+    span {
+      display: block;
+      overflow-wrap: anywhere;
+    }
+
+    span {
+      margin-top: var(--spacing-xs);
+      color: rgba(255, 255, 255, 0.55);
+      font-size: 12px;
+    }
+  }
+
+  &__config {
+    max-height: 280px;
+    margin: var(--spacing-md) 0;
+    padding: var(--spacing-lg);
+    overflow: auto;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+  }
+}

--- a/src/components/CodeIndexer/CodeIndexer.scss
+++ b/src/components/CodeIndexer/CodeIndexer.scss
@@ -1,4 +1,4 @@
-@use "@/styles/mixins" as *;
+@use "../../styles/mixins" as *;
 
 .code-indexer {
   max-width: 1120px;
@@ -143,11 +143,6 @@
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 
-    &--compact {
-      @include md {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-    }
   }
 
   &__feature {
@@ -189,15 +184,15 @@
     font-size: 24px;
   }
 
-  p {
+  > div > p:not(.code-indexer-promo__eyebrow) {
     margin: 0;
     color: rgba(255, 255, 255, 0.65);
     line-height: 1.55;
   }
 
   &__eyebrow {
-    margin-bottom: var(--spacing-xs) !important;
-    color: #9be5ff !important;
+    margin-bottom: var(--spacing-xs);
+    color: #9be5ff;
     font-size: 12px;
     font-weight: 700;
     text-transform: uppercase;

--- a/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 import { Button, Icon, TextInput } from "@gravity-ui/uikit";
 import {
@@ -14,9 +14,17 @@ import {
   buildCodeIndexerLoginUrl,
   CODE_INDEXER_BACKEND_URL,
 } from "./CodeIndexerLanding";
+import {
+  formatDate,
+  parseJsonBody,
+  progressPercent,
+  readApiError,
+  shortSha,
+} from "./utils";
 import "./CodeIndexer.scss";
 
 const ADMIN_RETURN_PATH = "/code-indexer/admin/";
+const ADMIN_SEARCH_DEBOUNCE_MS = 300;
 
 type GitHubUser = {
   githubUserId: string;
@@ -83,7 +91,12 @@ type AdminOverview = {
   };
 };
 
-type AuthState = "checking" | "authenticated" | "forbidden" | "unauthenticated";
+type AuthState =
+  | "checking"
+  | "authenticated"
+  | "error"
+  | "forbidden"
+  | "unauthenticated";
 
 class AdminApiError extends Error {
   readonly status: number;
@@ -95,48 +108,19 @@ class AdminApiError extends Error {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function readApiError(value: unknown) {
-  if (isRecord(value) && typeof value.error === "string") {
-    return value.error;
-  }
-  return "request failed";
-}
-
 async function adminApiRequest<T>(path: string): Promise<T> {
   const response = await fetch(`${CODE_INDEXER_BACKEND_URL}${path}`, {
     credentials: "include",
   });
   const text = await response.text();
-  const body: unknown = text ? JSON.parse(text) : null;
+  const body = parseJsonBody(text);
   if (!response.ok) {
-    throw new AdminApiError(response.status, readApiError(body));
+    throw new AdminApiError(
+      response.status,
+      readApiError(body, response.statusText || "request failed")
+    );
   }
   return body as T;
-}
-
-function formatDate(value?: string) {
-  if (!value) {
-    return "Never";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return date.toLocaleString("en-US", {
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
-}
-
-function shortSha(value?: string) {
-  return value ? value.slice(0, 12) : "n/a";
 }
 
 function formatNumber(value: number) {
@@ -157,22 +141,6 @@ function formatJobTarget(job: AdminJob) {
     return "Repository cleanup";
   }
   return "Default reindex";
-}
-
-function progressPercent(job: AdminJob) {
-  if (job.status === "completed") {
-    return 100;
-  }
-  const total =
-    job.totalFiles && job.totalFiles > 0 ? job.totalFiles : job.totalChunks ?? 0;
-  const processed =
-    job.totalFiles && job.totalFiles > 0
-      ? job.processedFiles
-      : job.processedChunks;
-  if (total <= 0) {
-    return job.status === "running" ? 12 : 0;
-  }
-  return Math.max(2, Math.min(100, Math.round((processed / total) * 100)));
 }
 
 function jobStatusIcon(status: AdminJob["status"]) {
@@ -216,6 +184,7 @@ function buildAdminQuery(params: {
 }
 
 export function CodeIndexerAdminDashboard() {
+  const adminRequestId = useRef(0);
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
   const [overview, setOverview] = useState<AdminOverview | null>(null);
@@ -227,8 +196,11 @@ export function CodeIndexerAdminDashboard() {
   const [repositoryStatus, setRepositoryStatus] = useState("");
   const [jobStatus, setJobStatus] = useState("");
   const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
 
   const loadAdminData = useCallback(async (silent = false) => {
+    const requestId = adminRequestId.current + 1;
+    adminRequestId.current = requestId;
     if (silent) {
       setRefreshing(true);
     } else {
@@ -238,12 +210,12 @@ export function CodeIndexerAdminDashboard() {
     try {
       const repositoryQuery = buildAdminQuery({
         limit: 500,
-        q: query.trim(),
+        q: debouncedQuery.trim(),
         status: repositoryStatus,
       });
       const jobQuery = buildAdminQuery({
         limit: 200,
-        q: query.trim(),
+        q: debouncedQuery.trim(),
         status: jobStatus,
       });
       const [overviewData, repositoriesData, jobsData] = await Promise.all([
@@ -261,29 +233,45 @@ export function CodeIndexerAdminDashboard() {
         ),
       ]);
 
+      if (requestId !== adminRequestId.current) {
+        return;
+      }
       setAuthState("authenticated");
       setUser(overviewData.user);
       setOverview(overviewData.overview);
       setRepositories(repositoriesData.repositories);
       setJobs(jobsData.jobs);
     } catch (err: unknown) {
+      if (requestId !== adminRequestId.current) {
+        return;
+      }
       if (err instanceof AdminApiError && err.status === 401) {
         setAuthState("unauthenticated");
       } else if (err instanceof AdminApiError && err.status === 403) {
         setAuthState("forbidden");
         setError(err.message);
       } else {
+        setAuthState((current) => (current === "checking" ? "error" : current));
         setError(err instanceof Error ? err.message : String(err));
       }
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (requestId === adminRequestId.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
-  }, [jobStatus, query, repositoryStatus]);
+  }, [debouncedQuery, jobStatus, repositoryStatus]);
 
   useEffect(() => {
     void loadAdminData();
   }, [loadAdminData]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedQuery(query);
+    }, ADMIN_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [query]);
 
   useEffect(() => {
     if (authState !== "authenticated" || !overview || overview.totals.activeJobs === 0) {
@@ -348,6 +336,23 @@ export function CodeIndexerAdminDashboard() {
           </p>
           <Button href="/code-indexer/dashboard/" view="outlined">
             Open user dashboard
+          </Button>
+        </section>
+      </main>
+    );
+  }
+
+  if (authState === "error") {
+    return (
+      <main className="code-indexer code-indexer-dashboard code-indexer-admin">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Admin</p>
+          <h1>Admin dashboard unavailable</h1>
+          <p className="code-indexer__lead">
+            {error || "The Code Indexer backend did not return admin data."}
+          </p>
+          <Button onClick={() => void loadAdminData()} size="xl" view="outlined">
+            Try again
           </Button>
         </section>
       </main>

--- a/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
@@ -1,0 +1,604 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ChangeEvent } from "react";
+import { Button, Icon, TextInput } from "@gravity-ui/uikit";
+import {
+  ArrowRotateRight,
+  CircleCheck,
+  CircleExclamation,
+  CircleInfo,
+  Magnifier,
+} from "@gravity-ui/icons";
+import {
+  buildCodeIndexerLoginUrl,
+  CODE_INDEXER_BACKEND_URL,
+} from "./CodeIndexerLanding";
+import "./CodeIndexer.scss";
+
+const ADMIN_RETURN_PATH = "/code-indexer/admin/";
+
+type GitHubUser = {
+  githubUserId: string;
+  login: string;
+};
+
+type AdminJob = {
+  createdAt: string;
+  currentPath?: string;
+  finishedAt?: string;
+  jobId: string;
+  jobKind:
+    | "full-index"
+    | "incremental-push"
+    | "delete-repo-index"
+    | "pr-index"
+    | "delete-pr-index";
+  lastError?: string;
+  owner: string;
+  phase: string;
+  processedChunks: number;
+  processedFiles: number;
+  prNumber?: number;
+  repo: string;
+  repoId: string;
+  startedAt?: string;
+  status: "pending" | "running" | "completed" | "failed";
+  totalChunks?: number;
+  totalFiles?: number;
+  updatedAt: string;
+};
+
+type AdminRepository = {
+  accountLogin: string;
+  accountType: string;
+  activeJob?: AdminJob;
+  activeJobs?: AdminJob[];
+  chunkCount?: number;
+  defaultBranch: string;
+  installationId: string;
+  installationStatus: string;
+  lastError?: string;
+  lastIndexedAt?: string;
+  lastIndexedSha?: string;
+  owner: string;
+  repo: string;
+  repoId: string;
+  status: "queued" | "indexing" | "ready" | "failed" | "deleted";
+};
+
+type AdminOverview = {
+  generatedAt: string;
+  recentJobs: AdminJob[];
+  totals: {
+    activeJobs: number;
+    apiTokens: number;
+    failedJobs: number;
+    indexedChunks: number;
+    installations: number;
+    repositories: number;
+    repositoriesByStatus: Record<string, number>;
+    revokedApiTokens: number;
+    users: number;
+  };
+};
+
+type AuthState = "checking" | "authenticated" | "forbidden" | "unauthenticated";
+
+class AdminApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "AdminApiError";
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readApiError(value: unknown) {
+  if (isRecord(value) && typeof value.error === "string") {
+    return value.error;
+  }
+  return "request failed";
+}
+
+async function adminApiRequest<T>(path: string): Promise<T> {
+  const response = await fetch(`${CODE_INDEXER_BACKEND_URL}${path}`, {
+    credentials: "include",
+  });
+  const text = await response.text();
+  const body: unknown = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new AdminApiError(response.status, readApiError(body));
+  }
+  return body as T;
+}
+
+function formatDate(value?: string) {
+  if (!value) {
+    return "Never";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString("en-US", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function shortSha(value?: string) {
+  return value ? value.slice(0, 12) : "n/a";
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatJobTarget(job: AdminJob) {
+  if (job.jobKind === "pr-index") {
+    return job.prNumber === undefined ? "PR index" : `PR #${job.prNumber}`;
+  }
+  if (job.jobKind === "delete-pr-index") {
+    return job.prNumber === undefined ? "PR cleanup" : `PR #${job.prNumber} cleanup`;
+  }
+  if (job.jobKind === "incremental-push") {
+    return "Default update";
+  }
+  if (job.jobKind === "delete-repo-index") {
+    return "Repository cleanup";
+  }
+  return "Default reindex";
+}
+
+function progressPercent(job: AdminJob) {
+  if (job.status === "completed") {
+    return 100;
+  }
+  const total =
+    job.totalFiles && job.totalFiles > 0 ? job.totalFiles : job.totalChunks ?? 0;
+  const processed =
+    job.totalFiles && job.totalFiles > 0
+      ? job.processedFiles
+      : job.processedChunks;
+  if (total <= 0) {
+    return job.status === "running" ? 12 : 0;
+  }
+  return Math.max(2, Math.min(100, Math.round((processed / total) * 100)));
+}
+
+function jobStatusIcon(status: AdminJob["status"]) {
+  if (status === "completed") {
+    return CircleCheck;
+  }
+  if (status === "failed") {
+    return CircleExclamation;
+  }
+  return CircleInfo;
+}
+
+function statusClass(status: string) {
+  return `code-indexer-dashboard__status code-indexer-dashboard__status--${status}`;
+}
+
+function activeJobs(repository: AdminRepository) {
+  if (repository.activeJobs && repository.activeJobs.length > 0) {
+    return repository.activeJobs;
+  }
+  return repository.activeJob ? [repository.activeJob] : [];
+}
+
+function buildAdminQuery(params: {
+  limit?: number;
+  q?: string;
+  status?: string;
+}) {
+  const query = new URLSearchParams();
+  if (params.limit) {
+    query.set("limit", String(params.limit));
+  }
+  if (params.status) {
+    query.set("status", params.status);
+  }
+  if (params.q) {
+    query.set("q", params.q);
+  }
+  const text = query.toString();
+  return text ? `?${text}` : "";
+}
+
+export function CodeIndexerAdminDashboard() {
+  const [authState, setAuthState] = useState<AuthState>("checking");
+  const [user, setUser] = useState<GitHubUser | null>(null);
+  const [overview, setOverview] = useState<AdminOverview | null>(null);
+  const [repositories, setRepositories] = useState<AdminRepository[]>([]);
+  const [jobs, setJobs] = useState<AdminJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState("");
+  const [repositoryStatus, setRepositoryStatus] = useState("");
+  const [jobStatus, setJobStatus] = useState("");
+  const [query, setQuery] = useState("");
+
+  const loadAdminData = useCallback(async (silent = false) => {
+    if (silent) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError("");
+    try {
+      const repositoryQuery = buildAdminQuery({
+        limit: 500,
+        q: query.trim(),
+        status: repositoryStatus,
+      });
+      const jobQuery = buildAdminQuery({
+        limit: 200,
+        q: query.trim(),
+        status: jobStatus,
+      });
+      const [overviewData, repositoriesData, jobsData] = await Promise.all([
+        adminApiRequest<{
+          overview: AdminOverview;
+          status: "ok";
+          user: GitHubUser;
+        }>("/api/admin/overview"),
+        adminApiRequest<{
+          repositories: AdminRepository[];
+          status: "ok";
+        }>(`/api/admin/repositories${repositoryQuery}`),
+        adminApiRequest<{ jobs: AdminJob[]; status: "ok" }>(
+          `/api/admin/jobs${jobQuery}`
+        ),
+      ]);
+
+      setAuthState("authenticated");
+      setUser(overviewData.user);
+      setOverview(overviewData.overview);
+      setRepositories(repositoriesData.repositories);
+      setJobs(jobsData.jobs);
+    } catch (err: unknown) {
+      if (err instanceof AdminApiError && err.status === 401) {
+        setAuthState("unauthenticated");
+      } else if (err instanceof AdminApiError && err.status === 403) {
+        setAuthState("forbidden");
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [jobStatus, query, repositoryStatus]);
+
+  useEffect(() => {
+    void loadAdminData();
+  }, [loadAdminData]);
+
+  useEffect(() => {
+    if (authState !== "authenticated" || !overview || overview.totals.activeJobs === 0) {
+      return undefined;
+    }
+    const intervalId = window.setInterval(() => {
+      void loadAdminData(true);
+    }, 5000);
+    return () => window.clearInterval(intervalId);
+  }, [authState, loadAdminData, overview]);
+
+  const repoStatusCounts = useMemo(
+    () =>
+      Object.entries(overview?.totals.repositoriesByStatus ?? {}).sort(([a], [b]) =>
+        a.localeCompare(b)
+      ),
+    [overview]
+  );
+
+  if (loading || authState === "checking") {
+    return (
+      <main className="code-indexer code-indexer-dashboard code-indexer-admin">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Admin</p>
+          <h1>Loading admin dashboard</h1>
+          <p className="code-indexer__lead">Checking your GitHub session.</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (authState === "unauthenticated") {
+    return (
+      <main className="code-indexer code-indexer-dashboard code-indexer-admin">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Admin</p>
+          <h1>Sign in with GitHub</h1>
+          <p className="code-indexer__lead">
+            Sign in with the operator GitHub account to view global Code Indexer
+            status.
+          </p>
+          <Button
+            href={buildCodeIndexerLoginUrl(ADMIN_RETURN_PATH)}
+            size="xl"
+            view="action"
+          >
+            Sign in
+          </Button>
+        </section>
+      </main>
+    );
+  }
+
+  if (authState === "forbidden") {
+    return (
+      <main className="code-indexer code-indexer-dashboard code-indexer-admin">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Admin</p>
+          <h1>Access denied</h1>
+          <p className="code-indexer__lead">
+            {error || "This GitHub account is not in the admin allowlist."}
+          </p>
+          <Button href="/code-indexer/dashboard/" view="outlined">
+            Open user dashboard
+          </Button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="code-indexer code-indexer-dashboard code-indexer-admin">
+      <section className="code-indexer-dashboard__header code-indexer-admin__header">
+        <div>
+          <p className="code-indexer__eyebrow">Admin</p>
+          <h1>Code Indexer Ops</h1>
+          <p className="code-indexer__lead">
+            Signed in as <strong>{user?.login}</strong>. Global read-only status
+            for hosted repository indexing.
+          </p>
+        </div>
+        <div className="code-indexer-dashboard__header-actions">
+          <Button
+            onClick={() => void loadAdminData(true)}
+            view="outlined"
+            disabled={refreshing}
+          >
+            <Icon data={ArrowRotateRight} size={16} />
+            {refreshing ? "Refreshing" : "Refresh"}
+          </Button>
+          <Button href="/code-indexer/dashboard/" view="outlined">
+            User dashboard
+          </Button>
+        </div>
+      </section>
+
+      {error && (
+        <div
+          className="code-indexer-dashboard__notice code-indexer-dashboard__notice--error"
+          role="status"
+        >
+          {error}
+        </div>
+      )}
+
+      {overview && (
+        <section className="code-indexer-admin__summary">
+          <div>
+            <span>Users</span>
+            <strong>{formatNumber(overview.totals.users)}</strong>
+          </div>
+          <div>
+            <span>Installations</span>
+            <strong>{formatNumber(overview.totals.installations)}</strong>
+          </div>
+          <div>
+            <span>Repositories</span>
+            <strong>{formatNumber(overview.totals.repositories)}</strong>
+          </div>
+          <div>
+            <span>Indexed chunks</span>
+            <strong>{formatNumber(overview.totals.indexedChunks)}</strong>
+          </div>
+          <div>
+            <span>Active jobs</span>
+            <strong>{formatNumber(overview.totals.activeJobs)}</strong>
+          </div>
+          <div>
+            <span>Failed jobs</span>
+            <strong>{formatNumber(overview.totals.failedJobs)}</strong>
+          </div>
+          <div>
+            <span>MCP tokens</span>
+            <strong>{formatNumber(overview.totals.apiTokens)}</strong>
+          </div>
+          <div>
+            <span>Revoked tokens</span>
+            <strong>{formatNumber(overview.totals.revokedApiTokens)}</strong>
+          </div>
+        </section>
+      )}
+
+      <section className="code-indexer-admin__filters">
+        <TextInput
+          aria-label="Search repositories and jobs"
+          startContent={<Icon data={Magnifier} size={16} />}
+          onUpdate={setQuery}
+          placeholder="owner/repo or job id"
+          size="l"
+          value={query}
+        />
+        <select
+          aria-label="Repository status"
+          className="code-indexer-dashboard__select"
+          onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            setRepositoryStatus(event.target.value)
+          }
+          value={repositoryStatus}
+        >
+          <option value="">All repositories</option>
+          <option value="ready">Ready</option>
+          <option value="queued">Queued</option>
+          <option value="indexing">Indexing</option>
+          <option value="failed">Failed</option>
+          <option value="deleted">Deleted</option>
+        </select>
+        <select
+          aria-label="Job status"
+          className="code-indexer-dashboard__select"
+          onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            setJobStatus(event.target.value)
+          }
+          value={jobStatus}
+        >
+          <option value="">All jobs</option>
+          <option value="pending">Pending</option>
+          <option value="running">Running</option>
+          <option value="completed">Completed</option>
+          <option value="failed">Failed</option>
+        </select>
+      </section>
+
+      {repoStatusCounts.length > 0 && (
+        <section className="code-indexer-admin__status-strip">
+          {repoStatusCounts.map(([status, count]) => (
+            <span key={status}>
+              {status}: <strong>{formatNumber(count)}</strong>
+            </span>
+          ))}
+          {overview && <span>Updated {formatDate(overview.generatedAt)}</span>}
+        </section>
+      )}
+
+      <section className="code-indexer-admin__layout">
+        <div className="code-indexer-dashboard__panel">
+          <div className="code-indexer-dashboard__panel-heading">
+            <div>
+              <p className="code-indexer__eyebrow">Repositories</p>
+              <h2>Global index status</h2>
+            </div>
+          </div>
+          <div className="code-indexer-admin__table-wrap">
+            <table className="code-indexer-admin__table">
+              <thead>
+                <tr>
+                  <th>Repository</th>
+                  <th>Installation</th>
+                  <th>Status</th>
+                  <th>Branch</th>
+                  <th>Chunks</th>
+                  <th>Last indexed</th>
+                  <th>Active jobs</th>
+                </tr>
+              </thead>
+              <tbody>
+                {repositories.map((repository) => (
+                  <tr key={repository.repoId}>
+                    <td>
+                      <strong>
+                        {repository.owner}/{repository.repo}
+                      </strong>
+                      <span>{repository.repoId}</span>
+                    </td>
+                    <td>
+                      <strong>{repository.accountLogin}</strong>
+                      <span>
+                        {repository.accountType} · {repository.installationStatus}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={statusClass(repository.status)}>
+                        {repository.status}
+                      </span>
+                    </td>
+                    <td>
+                      <strong>{repository.defaultBranch}</strong>
+                      <span>{shortSha(repository.lastIndexedSha)}</span>
+                    </td>
+                    <td>{formatNumber(repository.chunkCount ?? 0)}</td>
+                    <td>{formatDate(repository.lastIndexedAt)}</td>
+                    <td>
+                      {activeJobs(repository).length === 0 ? (
+                        <span>None</span>
+                      ) : (
+                        <div className="code-indexer-admin__job-stack">
+                          {activeJobs(repository).map((job) => (
+                            <span key={job.jobId}>
+                              {formatJobTarget(job)} · {job.phase}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <aside className="code-indexer-dashboard__side">
+          <section className="code-indexer-dashboard__panel">
+            <p className="code-indexer__eyebrow">Jobs</p>
+            <h2>Recent activity</h2>
+            <div className="code-indexer-admin__jobs">
+              {jobs.length === 0 ? (
+                <p className="code-indexer-dashboard__empty">No jobs found.</p>
+              ) : (
+                jobs.map((job) => (
+                  <article className="code-indexer-progress" key={job.jobId}>
+                    <div className="code-indexer-progress__heading">
+                      <strong>
+                        {job.owner}/{job.repo} · {formatJobTarget(job)}
+                      </strong>
+                      <span>{job.jobId}</span>
+                    </div>
+                    <span className={statusClass(job.status)}>
+                      <Icon data={jobStatusIcon(job.status)} size={16} />
+                      {job.status}
+                    </span>
+                    <div className="code-indexer-progress__bar">
+                      <span
+                        className="code-indexer-progress__bar-fill"
+                        style={{ width: `${progressPercent(job)}%` }}
+                      />
+                    </div>
+                    <div className="code-indexer-progress__meta">
+                      <span>Phase {job.phase}</span>
+                      <span>
+                        Files {job.processedFiles}/{job.totalFiles ?? "?"}
+                      </span>
+                      <span>
+                        Chunks {job.processedChunks}/{job.totalChunks ?? "?"}
+                      </span>
+                    </div>
+                    {job.currentPath && (
+                      <p className="code-indexer-progress__path">
+                        {job.currentPath}
+                      </p>
+                    )}
+                    <p className="code-indexer-progress__message">
+                      Updated {formatDate(job.updatedAt)}
+                    </p>
+                    {job.lastError && (
+                      <p className="code-indexer-progress__error">
+                        {job.lastError}
+                      </p>
+                    )}
+                  </article>
+                ))
+              )}
+            </div>
+          </section>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
@@ -185,6 +185,7 @@ function buildAdminQuery(params: {
 
 export function CodeIndexerAdminDashboard() {
   const adminRequestId = useRef(0);
+  const adminRefreshInFlight = useRef(false);
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
   const [overview, setOverview] = useState<AdminOverview | null>(null);
@@ -278,7 +279,13 @@ export function CodeIndexerAdminDashboard() {
       return undefined;
     }
     const intervalId = window.setInterval(() => {
-      void loadAdminData(true);
+      if (adminRefreshInFlight.current) {
+        return;
+      }
+      adminRefreshInFlight.current = true;
+      void loadAdminData(true).finally(() => {
+        adminRefreshInFlight.current = false;
+      });
     }, 5000);
     return () => window.clearInterval(intervalId);
   }, [authState, loadAdminData, overview]);

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -258,6 +258,7 @@ export function CodeIndexerDashboard() {
   const repositoriesRequestId = useRef(0);
   const repositoriesLoadingRequestId = useRef(0);
   const repositoriesPollInFlight = useRef(false);
+  const repositoriesPollErrorRef = useRef("");
   const selectedInstallationIdRef = useRef("");
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
@@ -279,6 +280,7 @@ export function CodeIndexerDashboard() {
     repositoriesRequestId.current += 1;
     repositoriesLoadingRequestId.current = 0;
     repositoriesPollInFlight.current = false;
+    repositoriesPollErrorRef.current = "";
     selectedInstallationIdRef.current = "";
     setAuthState("unauthenticated");
     setUser(null);
@@ -434,12 +436,22 @@ export function CodeIndexerDashboard() {
       }
       repositoriesPollInFlight.current = true;
       void loadRepositories(installationId, { silent: true })
+        .then(() => {
+          const pollingError = repositoriesPollErrorRef.current;
+          if (!pollingError) {
+            return;
+          }
+          repositoriesPollErrorRef.current = "";
+          setError((current) => (current === pollingError ? "" : current));
+        })
         .catch((err: unknown) => {
           if (isUnauthorizedError(err)) {
             resetSession("Session expired. Sign in again.");
             return;
           }
-          setError(err instanceof Error ? err.message : String(err));
+          const message = err instanceof Error ? err.message : String(err);
+          repositoriesPollErrorRef.current = message;
+          setError(message);
         })
         .finally(() => {
           repositoriesPollInFlight.current = false;
@@ -509,6 +521,8 @@ export function CodeIndexerDashboard() {
     event.preventDefault();
     setError("");
     setActionMessage("");
+    const tokenCreatedMessage =
+      "Token created. Copy it now; it will not be shown again.";
     try {
       const data = await apiRequest<{ status: "ok"; token: CreatedToken }>(
         "/api/tokens",
@@ -518,14 +532,26 @@ export function CodeIndexerDashboard() {
         }
       );
       setCreatedToken(data.token);
-      setActionMessage("Token created. Copy it now; it will not be shown again.");
-      await loadTokens();
+      setActionMessage(tokenCreatedMessage);
     } catch (err: unknown) {
       if (isUnauthorizedError(err)) {
         resetSession("Session expired. Sign in again.");
         return;
       }
       setError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    try {
+      await loadTokens();
+    } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
+      setActionMessage(
+        `${tokenCreatedMessage} Token list could not refresh; reload the dashboard to update it.`
+      );
     }
   };
 
@@ -572,18 +598,31 @@ export function CodeIndexerDashboard() {
   const handleRevokeToken = async (tokenId: string) => {
     setError("");
     setActionMessage("");
+    const tokenRevokedMessage = "Token revoked.";
     try {
       await apiRequest<null>(`/api/tokens/${encodeURIComponent(tokenId)}`, {
         method: "DELETE",
       });
-      setActionMessage("Token revoked.");
-      await loadTokens();
+      setActionMessage(tokenRevokedMessage);
     } catch (err: unknown) {
       if (isUnauthorizedError(err)) {
         resetSession("Session expired. Sign in again.");
         return;
       }
       setError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    try {
+      await loadTokens();
+    } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
+      setActionMessage(
+        `${tokenRevokedMessage} Token list could not refresh; reload the dashboard to update it.`
+      );
     }
   };
 

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -257,6 +257,8 @@ function hasActiveDefaultBranchJob(repository: Repository) {
 export function CodeIndexerDashboard() {
   const repositoriesRequestId = useRef(0);
   const repositoriesLoadingRequestId = useRef(0);
+  const repositoriesPollInFlight = useRef(false);
+  const selectedInstallationIdRef = useRef("");
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
   const [installations, setInstallations] = useState<Installation[]>([]);
@@ -276,6 +278,8 @@ export function CodeIndexerDashboard() {
   const resetSession = useCallback((message = "") => {
     repositoriesRequestId.current += 1;
     repositoriesLoadingRequestId.current = 0;
+    repositoriesPollInFlight.current = false;
+    selectedInstallationIdRef.current = "";
     setAuthState("unauthenticated");
     setUser(null);
     setInstallations([]);
@@ -381,6 +385,7 @@ export function CodeIndexerDashboard() {
 
       setUser(me.user);
       setInstallations(installationsData.installations);
+      selectedInstallationIdRef.current = firstInstallationId;
       setSelectedInstallationId(firstInstallationId);
       setAuthState("authenticated");
       if (firstInstallationId) {
@@ -420,18 +425,28 @@ export function CodeIndexerDashboard() {
       return undefined;
     }
     const intervalId = window.setInterval(() => {
-      void loadRepositories(selectedInstallationId, { silent: true }).catch(
-        (err: unknown) => {
+      if (repositoriesPollInFlight.current) {
+        return;
+      }
+      const installationId = selectedInstallationIdRef.current;
+      if (!installationId) {
+        return;
+      }
+      repositoriesPollInFlight.current = true;
+      void loadRepositories(installationId, { silent: true })
+        .catch((err: unknown) => {
           if (isUnauthorizedError(err)) {
             resetSession("Session expired. Sign in again.");
             return;
           }
           setError(err instanceof Error ? err.message : String(err));
-        }
-      );
+        })
+        .finally(() => {
+          repositoriesPollInFlight.current = false;
+        });
     }, 3000);
     return () => window.clearInterval(intervalId);
-  }, [loadRepositories, resetSession, selectedInstallationId, shouldPollRepositories]);
+  }, [loadRepositories, resetSession, shouldPollRepositories]);
 
   const tokenForConfig = createdToken?.plaintextToken ?? "<token>";
   const mcpConfig = useMemo(
@@ -473,9 +488,11 @@ export function CodeIndexerDashboard() {
     event: ChangeEvent<HTMLSelectElement>
   ) => {
     const installationId = event.target.value;
+    selectedInstallationIdRef.current = installationId;
     setSelectedInstallationId(installationId);
     setError("");
     setActionMessage("");
+    setRepositories([]);
     setReindexingRepoIds(new Set());
     try {
       await loadRepositories(installationId);
@@ -541,7 +558,10 @@ export function CodeIndexerDashboard() {
     }
 
     try {
-      await loadRepositories(selectedInstallationId, { silent: true });
+      const installationId = selectedInstallationIdRef.current;
+      if (installationId) {
+        await loadRepositories(installationId, { silent: true });
+      }
     } catch (err: unknown) {
       if (isUnauthorizedError(err)) {
         resetSession("Session expired. Sign in again.");

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { Button, Icon, TextInput } from "@gravity-ui/uikit";
 import {
@@ -20,6 +20,13 @@ import {
   CODE_INDEXER_BACKEND_URL,
   CODE_INDEXER_INSTALL_URL,
 } from "./CodeIndexerLanding";
+import {
+  formatDate,
+  parseJsonBody,
+  progressPercent,
+  readApiError,
+  shortSha,
+} from "./utils";
 import "./CodeIndexer.scss";
 
 const MCP_AGENT_USAGE_PROMPT = `Use ydb-qdrant-code-indexer as searchable project memory for indexed GitHub repositories.
@@ -97,7 +104,7 @@ type CreatedToken = {
   tokenId: string;
 };
 
-type AuthState = "checking" | "authenticated" | "unauthenticated";
+type AuthState = "checking" | "authenticated" | "error" | "unauthenticated";
 type LoadRepositoriesOptions = {
   silent?: boolean;
 };
@@ -112,17 +119,6 @@ class DashboardApiError extends Error {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function readApiError(value: unknown): string {
-  if (isRecord(value) && typeof value.error === "string") {
-    return value.error;
-  }
-  return "request failed";
-}
-
 async function apiRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
   const headers = new Headers(options.headers);
   if (options.body && !headers.has("content-type")) {
@@ -135,34 +131,16 @@ async function apiRequest<T>(path: string, options: RequestInit = {}): Promise<T
     headers,
   });
   const text = await response.text();
-  const body: unknown = text ? JSON.parse(text) : null;
+  const body = parseJsonBody(text);
 
   if (!response.ok) {
-    throw new DashboardApiError(response.status, readApiError(body));
+    throw new DashboardApiError(
+      response.status,
+      readApiError(body, response.statusText || "request failed")
+    );
   }
 
   return body as T;
-}
-
-function formatDate(value?: string) {
-  if (!value) {
-    return "Never";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return date.toLocaleString("en-US", {
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
-}
-
-function shortSha(value?: string) {
-  return value ? value.slice(0, 12) : "n/a";
 }
 
 function statusIcon(status: RepositoryStatus): IconData {
@@ -228,26 +206,6 @@ function formatProgressCount(processed: number, total?: number) {
   return `${processed}/${total ?? "?"}`;
 }
 
-function progressPercent(job: ActiveJob) {
-  let total = 0;
-  let processed = 0;
-  if (job.totalFiles && job.totalFiles > 0) {
-    total = job.totalFiles;
-    processed = job.processedFiles;
-  } else if (job.totalChunks && job.totalChunks > 0) {
-    total = job.totalChunks;
-    processed = job.processedChunks;
-  }
-
-  if (job.status === "completed") {
-    return 100;
-  }
-  if (total <= 0) {
-    return job.status === "running" ? 12 : 0;
-  }
-  return Math.max(2, Math.min(100, Math.round((processed / total) * 100)));
-}
-
 function formatElapsed(startedAt?: string) {
   if (!startedAt) {
     return "unknown";
@@ -293,6 +251,7 @@ function hasActiveDefaultBranchJob(repository: Repository) {
 }
 
 export function CodeIndexerDashboard() {
+  const repositoriesRequestId = useRef(0);
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
   const [installations, setInstallations] = useState<Installation[]>([]);
@@ -315,9 +274,12 @@ export function CodeIndexerDashboard() {
       options: LoadRepositoriesOptions = {}
     ) => {
       if (!installationId) {
+        repositoriesRequestId.current += 1;
         setRepositories([]);
         return;
       }
+      const requestId = repositoriesRequestId.current + 1;
+      repositoriesRequestId.current = requestId;
       if (!options.silent) {
         setRepositoriesLoading(true);
       }
@@ -330,6 +292,9 @@ export function CodeIndexerDashboard() {
             installationId
           )}`
         );
+        if (requestId !== repositoriesRequestId.current) {
+          return;
+        }
         setRepositories(data.repositories);
         setReindexingRepoIds((current) => {
           const next = new Set(current);
@@ -345,8 +310,12 @@ export function CodeIndexerDashboard() {
           }
           return next;
         });
+      } catch (err: unknown) {
+        if (requestId === repositoriesRequestId.current) {
+          throw err;
+        }
       } finally {
-        if (!options.silent) {
+        if (!options.silent && requestId === repositoriesRequestId.current) {
           setRepositoriesLoading(false);
         }
       }
@@ -389,7 +358,7 @@ export function CodeIndexerDashboard() {
       if (err instanceof DashboardApiError && err.status === 401) {
         setAuthState("unauthenticated");
       } else {
-        setAuthState("unauthenticated");
+        setAuthState("error");
         setError(err instanceof Error ? err.message : String(err));
       }
     } finally {
@@ -419,6 +388,13 @@ export function CodeIndexerDashboard() {
     const intervalId = window.setInterval(() => {
       void loadRepositories(selectedInstallationId, { silent: true }).catch(
         (err: unknown) => {
+          if (err instanceof DashboardApiError && err.status === 401) {
+            setAuthState("unauthenticated");
+            setRepositories([]);
+            setReindexingRepoIds(new Set());
+            setError("Session expired. Sign in again.");
+            return;
+          }
           setError(err instanceof Error ? err.message : String(err));
         }
       );
@@ -447,8 +423,19 @@ export function CodeIndexerDashboard() {
   );
 
   const copyText = async (value: string, message: string) => {
-    await navigator.clipboard.writeText(value);
-    setActionMessage(message);
+    setError("");
+    if (!navigator.clipboard?.writeText) {
+      setActionMessage("");
+      setError("Clipboard copy is unavailable in this browser context.");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      setActionMessage(message);
+    } catch {
+      setActionMessage("");
+      setError("Could not copy to clipboard. Select and copy the text manually.");
+    }
   };
 
   const handleInstallationChange = async (
@@ -594,6 +581,14 @@ export function CodeIndexerDashboard() {
             Authorize the GitHub App to view repositories you installed it on,
             then manage indexing status and hosted MCP tokens here.
           </p>
+          {error && (
+            <div
+              className="code-indexer-dashboard__notice code-indexer-dashboard__notice--error"
+              role="status"
+            >
+              {error}
+            </div>
+          )}
           <div className="code-indexer__actions">
             <Button href={buildCodeIndexerLoginUrl()} size="xl" view="action">
               Sign in
@@ -601,13 +596,30 @@ export function CodeIndexerDashboard() {
             <Button
               href={CODE_INDEXER_INSTALL_URL}
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
               size="xl"
               view="outlined"
             >
               Install GitHub App
             </Button>
           </div>
+        </section>
+      </main>
+    );
+  }
+
+  if (authState === "error") {
+    return (
+      <main className="code-indexer code-indexer-dashboard">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Dashboard</p>
+          <h1>Dashboard unavailable</h1>
+          <p className="code-indexer__lead">
+            {error || "The Code Indexer backend did not return dashboard data."}
+          </p>
+          <Button onClick={() => void initialize()} size="xl" view="outlined">
+            Try again
+          </Button>
         </section>
       </main>
     );
@@ -625,7 +637,11 @@ export function CodeIndexerDashboard() {
           </p>
         </div>
         <div className="code-indexer-dashboard__header-actions">
-          <Button href={CODE_INDEXER_INSTALL_URL} target="_blank" rel="noopener">
+          <Button
+            href={CODE_INDEXER_INSTALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Install on more repositories
           </Button>
           <Button onClick={handleLogout} view="outlined">
@@ -680,7 +696,7 @@ export function CodeIndexerDashboard() {
               <Button
                 href={CODE_INDEXER_INSTALL_URL}
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
                 view="outlined"
               >
                 Select repositories

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -526,7 +526,6 @@ export function CodeIndexerDashboard() {
       setActionMessage(
         `Reindex job ${data.job.jobId} queued. Refreshing status automatically.`
       );
-      await loadRepositories(selectedInstallationId, { silent: true });
     } catch (err: unknown) {
       if (isUnauthorizedError(err)) {
         resetSession("Session expired. Sign in again.");
@@ -538,6 +537,15 @@ export function CodeIndexerDashboard() {
         return next;
       });
       setError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    try {
+      await loadRepositories(selectedInstallationId, { silent: true });
+    } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+      }
     }
   };
 

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -1,0 +1,629 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+import { Button, Icon, TextInput } from "@gravity-ui/uikit";
+import {
+  ArrowRotateRight,
+  CircleCheck,
+  CircleExclamation,
+  CircleInfo,
+  CircleXmark,
+  Copy,
+  Key,
+  Plus,
+  TrashBin,
+} from "@gravity-ui/icons";
+import type { IconData } from "@gravity-ui/uikit";
+import {
+  buildCodeIndexerLoginUrl,
+  CODE_INDEXER_BACKEND_URL,
+  CODE_INDEXER_INSTALL_URL,
+} from "./CodeIndexerLanding";
+import "./CodeIndexer.scss";
+
+type GitHubUser = {
+  githubUserId: string;
+  login: string;
+};
+
+type Installation = {
+  accountLogin: string;
+  accountType: string;
+  installationId: string;
+  status: string;
+};
+
+type RepositoryStatus = "queued" | "indexing" | "ready" | "failed" | "deleted";
+
+type Repository = {
+  chunkCount?: number;
+  defaultBranch: string;
+  installationId: string;
+  lastError?: string;
+  lastIndexedAt?: string;
+  lastIndexedSha?: string;
+  owner: string;
+  repo: string;
+  repoId: string;
+  status: RepositoryStatus;
+};
+
+type ApiToken = {
+  githubUserId: string;
+  name: string;
+  revoked: boolean;
+  tokenId: string;
+};
+
+type CreatedToken = {
+  name: string;
+  plaintextToken: string;
+  tokenId: string;
+};
+
+type AuthState = "checking" | "authenticated" | "unauthenticated";
+
+class DashboardApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "DashboardApiError";
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readApiError(value: unknown): string {
+  if (isRecord(value) && typeof value.error === "string") {
+    return value.error;
+  }
+  return "request failed";
+}
+
+async function apiRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const headers = new Headers(options.headers);
+  if (options.body && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+
+  const response = await fetch(`${CODE_INDEXER_BACKEND_URL}${path}`, {
+    ...options,
+    credentials: "include",
+    headers,
+  });
+  const text = await response.text();
+  const body: unknown = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    throw new DashboardApiError(response.status, readApiError(body));
+  }
+
+  return body as T;
+}
+
+function formatDate(value?: string) {
+  if (!value) {
+    return "Never";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString("en-US", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function shortSha(value?: string) {
+  return value ? value.slice(0, 12) : "n/a";
+}
+
+function statusIcon(status: RepositoryStatus): IconData {
+  if (status === "ready") {
+    return CircleCheck;
+  }
+  if (status === "failed") {
+    return CircleExclamation;
+  }
+  if (status === "deleted") {
+    return CircleXmark;
+  }
+  return CircleInfo;
+}
+
+function statusLabel(status: RepositoryStatus) {
+  if (status === "queued") {
+    return "Queued";
+  }
+  if (status === "indexing") {
+    return "Indexing";
+  }
+  if (status === "ready") {
+    return "Ready";
+  }
+  if (status === "failed") {
+    return "Failed";
+  }
+  return "Deleted";
+}
+
+export function CodeIndexerDashboard() {
+  const [authState, setAuthState] = useState<AuthState>("checking");
+  const [user, setUser] = useState<GitHubUser | null>(null);
+  const [installations, setInstallations] = useState<Installation[]>([]);
+  const [selectedInstallationId, setSelectedInstallationId] = useState("");
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [tokens, setTokens] = useState<ApiToken[]>([]);
+  const [createdToken, setCreatedToken] = useState<CreatedToken | null>(null);
+  const [tokenName, setTokenName] = useState("Local coding agent");
+  const [loading, setLoading] = useState(true);
+  const [repositoriesLoading, setRepositoriesLoading] = useState(false);
+  const [actionMessage, setActionMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const loadRepositories = useCallback(async (installationId: string) => {
+    if (!installationId) {
+      setRepositories([]);
+      return;
+    }
+    setRepositoriesLoading(true);
+    try {
+      const data = await apiRequest<{
+        repositories: Repository[];
+        status: "ok";
+      }>(`/api/repositories?installationId=${encodeURIComponent(installationId)}`);
+      setRepositories(data.repositories);
+    } finally {
+      setRepositoriesLoading(false);
+    }
+  }, []);
+
+  const loadTokens = useCallback(async () => {
+    const data = await apiRequest<{ status: "ok"; tokens: ApiToken[] }>("/api/tokens");
+    setTokens(data.tokens);
+  }, []);
+
+  const initialize = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    setActionMessage("");
+    try {
+      const me = await apiRequest<{ status: "ok"; user: GitHubUser }>("/api/me");
+      const installationsData = await apiRequest<{
+        installations: Installation[];
+        status: "ok";
+      }>("/api/installations");
+      await loadTokens();
+
+      const activeInstallations = installationsData.installations.filter(
+        (installation) => installation.status !== "deleted"
+      );
+      const firstInstallationId = activeInstallations[0]?.installationId ?? "";
+
+      setUser(me.user);
+      setInstallations(installationsData.installations);
+      setSelectedInstallationId(firstInstallationId);
+      setAuthState("authenticated");
+      if (firstInstallationId) {
+        await loadRepositories(firstInstallationId);
+      } else {
+        setRepositories([]);
+      }
+    } catch (err: unknown) {
+      if (err instanceof DashboardApiError && err.status === 401) {
+        setAuthState("unauthenticated");
+      } else {
+        setAuthState("unauthenticated");
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [loadRepositories, loadTokens]);
+
+  useEffect(() => {
+    void initialize();
+  }, [initialize]);
+
+  const tokenForConfig = createdToken?.plaintextToken ?? "<token>";
+  const mcpConfig = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          mcpServers: {
+            "ydb-qdrant-code-indexer": {
+              headers: {
+                Authorization: `Bearer ${tokenForConfig}`,
+              },
+              url: `${CODE_INDEXER_BACKEND_URL}/mcp`,
+            },
+          },
+        },
+        null,
+        2
+      ),
+    [tokenForConfig]
+  );
+
+  const copyText = async (value: string, message: string) => {
+    await navigator.clipboard.writeText(value);
+    setActionMessage(message);
+  };
+
+  const handleInstallationChange = async (
+    event: ChangeEvent<HTMLSelectElement>
+  ) => {
+    const installationId = event.target.value;
+    setSelectedInstallationId(installationId);
+    setError("");
+    setActionMessage("");
+    try {
+      await loadRepositories(installationId);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleCreateToken = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError("");
+    setActionMessage("");
+    try {
+      const data = await apiRequest<{ status: "ok"; token: CreatedToken }>(
+        "/api/tokens",
+        {
+          body: JSON.stringify({ name: tokenName }),
+          method: "POST",
+        }
+      );
+      setCreatedToken(data.token);
+      setActionMessage("Token created. Copy it now; it will not be shown again.");
+      await loadTokens();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleReindex = async (repoId: string) => {
+    setError("");
+    setActionMessage("");
+    try {
+      await apiRequest<null>(`/api/repositories/${encodeURIComponent(repoId)}/reindex`, {
+        method: "POST",
+      });
+      setActionMessage("Reindex job queued.");
+      await loadRepositories(selectedInstallationId);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleRevokeToken = async (tokenId: string) => {
+    setError("");
+    setActionMessage("");
+    try {
+      await apiRequest<null>(`/api/tokens/${encodeURIComponent(tokenId)}`, {
+        method: "DELETE",
+      });
+      setActionMessage("Token revoked.");
+      await loadTokens();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleLogout = async () => {
+    setError("");
+    try {
+      await apiRequest<null>("/api/logout", { method: "POST" });
+      setAuthState("unauthenticated");
+      setUser(null);
+      setInstallations([]);
+      setRepositories([]);
+      setTokens([]);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleDeleteMyData = async () => {
+    if (
+      !window.confirm(
+        "Delete sessions, tokens, linked installations, repository rows, and indexed data where eligible?"
+      )
+    ) {
+      return;
+    }
+    setError("");
+    setActionMessage("");
+    try {
+      await apiRequest<{
+        deletedInstallations: number;
+        deletedRepositories: number;
+        status: "ok";
+      }>("/api/privacy/delete-my-data", { method: "POST" });
+      setAuthState("unauthenticated");
+      setUser(null);
+      setInstallations([]);
+      setRepositories([]);
+      setTokens([]);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (loading || authState === "checking") {
+    return (
+      <main className="code-indexer code-indexer-dashboard">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Dashboard</p>
+          <h1>Loading Code Indexer</h1>
+          <p className="code-indexer__lead">Checking your GitHub session.</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (authState === "unauthenticated") {
+    return (
+      <main className="code-indexer code-indexer-dashboard">
+        <section className="code-indexer-dashboard__panel">
+          <p className="code-indexer__eyebrow">Dashboard</p>
+          <h1>Sign in with GitHub</h1>
+          <p className="code-indexer__lead">
+            Authorize the GitHub App to view repositories you installed it on,
+            then manage indexing status and hosted MCP tokens here.
+          </p>
+          <div className="code-indexer__actions">
+            <Button href={buildCodeIndexerLoginUrl()} size="xl" view="action">
+              Sign in
+            </Button>
+            <Button
+              href={CODE_INDEXER_INSTALL_URL}
+              target="_blank"
+              rel="noopener"
+              size="xl"
+              view="outlined"
+            >
+              Install GitHub App
+            </Button>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="code-indexer code-indexer-dashboard">
+      <section className="code-indexer-dashboard__header">
+        <div>
+          <p className="code-indexer__eyebrow">Dashboard</p>
+          <h1>Code Indexer</h1>
+          <p className="code-indexer__lead">
+            Signed in as <strong>{user?.login}</strong>. Manage repository
+            indexing and MCP access for coding agents.
+          </p>
+        </div>
+        <div className="code-indexer-dashboard__header-actions">
+          <Button href={CODE_INDEXER_INSTALL_URL} target="_blank" rel="noopener">
+            Install on more repositories
+          </Button>
+          <Button onClick={handleLogout} view="outlined">
+            Logout
+          </Button>
+        </div>
+      </section>
+
+      {(error || actionMessage) && (
+        <div
+          className={`code-indexer-dashboard__notice ${
+            error ? "code-indexer-dashboard__notice--error" : ""
+          }`}
+          role="status"
+        >
+          {error || actionMessage}
+        </div>
+      )}
+
+      <section className="code-indexer-dashboard__grid">
+        <div className="code-indexer-dashboard__panel">
+          <div className="code-indexer-dashboard__panel-heading">
+            <div>
+              <p className="code-indexer__eyebrow">Repositories</p>
+              <h2>Index status</h2>
+            </div>
+            <select
+              className="code-indexer-dashboard__select"
+              value={selectedInstallationId}
+              onChange={handleInstallationChange}
+              aria-label="GitHub App installation"
+            >
+              {installations.length === 0 && (
+                <option value="">No installations</option>
+              )}
+              {installations.map((installation) => (
+                <option
+                  key={installation.installationId}
+                  value={installation.installationId}
+                >
+                  {installation.accountLogin} ({installation.status})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {repositoriesLoading ? (
+            <p className="code-indexer-dashboard__empty">Loading repositories.</p>
+          ) : repositories.length === 0 ? (
+            <div className="code-indexer-dashboard__empty">
+              <p>No repositories are linked yet.</p>
+              <Button
+                href={CODE_INDEXER_INSTALL_URL}
+                target="_blank"
+                rel="noopener"
+                view="outlined"
+              >
+                Select repositories
+              </Button>
+            </div>
+          ) : (
+            <div className="code-indexer-dashboard__repo-list">
+              {repositories.map((repository) => (
+                <article
+                  className="code-indexer-dashboard__repo"
+                  key={repository.repoId}
+                >
+                  <div className="code-indexer-dashboard__repo-main">
+                    <div>
+                      <h3>
+                        {repository.owner}/{repository.repo}
+                      </h3>
+                      <p>
+                        Branch {repository.defaultBranch} · SHA{" "}
+                        {shortSha(repository.lastIndexedSha)}
+                      </p>
+                    </div>
+                    <span
+                      className={`code-indexer-dashboard__status code-indexer-dashboard__status--${repository.status}`}
+                    >
+                      <Icon data={statusIcon(repository.status)} size={16} />
+                      {statusLabel(repository.status)}
+                    </span>
+                  </div>
+                  <dl className="code-indexer-dashboard__repo-meta">
+                    <div>
+                      <dt>Chunks</dt>
+                      <dd>{repository.chunkCount ?? 0}</dd>
+                    </div>
+                    <div>
+                      <dt>Last indexed</dt>
+                      <dd>{formatDate(repository.lastIndexedAt)}</dd>
+                    </div>
+                    {repository.lastError && (
+                      <div>
+                        <dt>Error</dt>
+                        <dd>{repository.lastError}</dd>
+                      </div>
+                    )}
+                  </dl>
+                  <Button
+                    onClick={() => void handleReindex(repository.repoId)}
+                    view="outlined"
+                    disabled={repository.status === "deleted"}
+                  >
+                    <Icon data={ArrowRotateRight} size={16} />
+                    Reindex
+                  </Button>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <aside className="code-indexer-dashboard__side">
+          <section className="code-indexer-dashboard__panel">
+            <div className="code-indexer-dashboard__panel-heading">
+              <div>
+                <p className="code-indexer__eyebrow">MCP tokens</p>
+                <h2>Agent access</h2>
+              </div>
+              <Icon data={Key} size={22} />
+            </div>
+            <form
+              className="code-indexer-dashboard__token-form"
+              onSubmit={handleCreateToken}
+            >
+              <TextInput
+                aria-label="Token name"
+                value={tokenName}
+                onUpdate={setTokenName}
+                size="l"
+              />
+              <Button type="submit" view="action" size="l">
+                <Icon data={Plus} size={16} />
+                Create
+              </Button>
+            </form>
+
+            {createdToken && (
+              <div className="code-indexer-dashboard__created-token">
+                <p>New token</p>
+                <code>{createdToken.plaintextToken}</code>
+                <Button
+                  onClick={() =>
+                    void copyText(createdToken.plaintextToken, "Token copied.")
+                  }
+                  view="outlined"
+                >
+                  <Icon data={Copy} size={16} />
+                  Copy token
+                </Button>
+              </div>
+            )}
+
+            <div className="code-indexer-dashboard__token-list">
+              {tokens.length === 0 ? (
+                <p className="code-indexer-dashboard__empty">
+                  Create a token before connecting an agent.
+                </p>
+              ) : (
+                tokens.map((token) => (
+                  <div
+                    className="code-indexer-dashboard__token"
+                    key={token.tokenId}
+                  >
+                    <div>
+                      <strong>{token.name}</strong>
+                      <span>{token.revoked ? "Revoked" : "Active"}</span>
+                    </div>
+                    <Button
+                      onClick={() => void handleRevokeToken(token.tokenId)}
+                      view="outlined-danger"
+                      disabled={token.revoked}
+                    >
+                      <Icon data={TrashBin} size={16} />
+                    </Button>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="code-indexer-dashboard__panel">
+            <p className="code-indexer__eyebrow">MCP config</p>
+            <h2>Use in coding agents</h2>
+            <pre className="code-indexer-dashboard__config">{mcpConfig}</pre>
+            <Button
+              onClick={() => void copyText(mcpConfig, "MCP config copied.")}
+              view="outlined"
+            >
+              <Icon data={Copy} size={16} />
+              Copy config
+            </Button>
+          </section>
+
+          <section className="code-indexer-dashboard__panel code-indexer-dashboard__panel--danger">
+            <p className="code-indexer__eyebrow">Privacy</p>
+            <h2>Delete my data</h2>
+            <p>
+              Removes sessions, tokens, GitHub user data, linked installations,
+              repository rows, and indexed collections where eligible.
+            </p>
+            <Button onClick={handleDeleteMyData} view="outlined-danger">
+              Delete my data
+            </Button>
+          </section>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -256,6 +256,7 @@ function hasActiveDefaultBranchJob(repository: Repository) {
 
 export function CodeIndexerDashboard() {
   const repositoriesRequestId = useRef(0);
+  const repositoriesLoadingRequestId = useRef(0);
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
   const [installations, setInstallations] = useState<Installation[]>([]);
@@ -274,6 +275,7 @@ export function CodeIndexerDashboard() {
 
   const resetSession = useCallback((message = "") => {
     repositoriesRequestId.current += 1;
+    repositoriesLoadingRequestId.current = 0;
     setAuthState("unauthenticated");
     setUser(null);
     setInstallations([]);
@@ -294,12 +296,15 @@ export function CodeIndexerDashboard() {
     ) => {
       if (!installationId) {
         repositoriesRequestId.current += 1;
+        repositoriesLoadingRequestId.current = 0;
         setRepositories([]);
+        setRepositoriesLoading(false);
         return;
       }
       const requestId = repositoriesRequestId.current + 1;
       repositoriesRequestId.current = requestId;
       if (!options.silent) {
+        repositoriesLoadingRequestId.current = requestId;
         setRepositoriesLoading(true);
       }
       try {
@@ -316,15 +321,22 @@ export function CodeIndexerDashboard() {
         }
         setRepositories(data.repositories);
         setReindexingRepoIds((current) => {
+          const repositoriesById = new Map(
+            data.repositories.map((repository) => [
+              repository.repoId,
+              repository,
+            ])
+          );
           const next = new Set(current);
-          for (const repository of data.repositories) {
+          for (const repoId of Array.from(next)) {
+            const repository = repositoriesById.get(repoId);
             if (
-              next.has(repository.repoId) &&
+              !repository ||
               repository.status !== "queued" &&
-              repository.status !== "indexing" &&
-              !hasActiveDefaultBranchJob(repository)
+                repository.status !== "indexing" &&
+                !hasActiveDefaultBranchJob(repository)
             ) {
-              next.delete(repository.repoId);
+              next.delete(repoId);
             }
           }
           return next;
@@ -334,7 +346,10 @@ export function CodeIndexerDashboard() {
           throw err;
         }
       } finally {
-        if (!options.silent && requestId === repositoriesRequestId.current) {
+        if (
+          !options.silent &&
+          requestId === repositoriesLoadingRequestId.current
+        ) {
           setRepositoriesLoading(false);
         }
       }
@@ -501,13 +516,6 @@ export function CodeIndexerDashboard() {
     setError("");
     setActionMessage("");
     setReindexingRepoIds((current) => new Set(current).add(repoId));
-    setRepositories((current) =>
-      current.map((repository) =>
-        repository.repoId === repoId
-          ? { ...repository, status: "queued" }
-          : repository
-      )
-    );
     try {
       const data = await apiRequest<{
         job: QueuedIndexingJob;

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -36,7 +36,27 @@ type Installation = {
 
 type RepositoryStatus = "queued" | "indexing" | "ready" | "failed" | "deleted";
 
+type ActiveJob = {
+  createdAt: string;
+  currentPath?: string;
+  finishedAt?: string;
+  jobId: string;
+  lastError?: string;
+  message?: string;
+  phase: string;
+  processedChunks: number;
+  processedFiles: number;
+  startedAt?: string;
+  status: "pending" | "running" | "completed" | "failed";
+  totalChunks?: number;
+  totalFiles?: number;
+  updatedAt: string;
+};
+
+type QueuedIndexingJob = Pick<ActiveJob, "jobId" | "phase" | "status">;
+
 type Repository = {
+  activeJob?: ActiveJob;
   chunkCount?: number;
   defaultBranch: string;
   installationId: string;
@@ -159,6 +179,71 @@ function statusLabel(status: RepositoryStatus) {
   return "Deleted";
 }
 
+function activeJobLabel(job: ActiveJob) {
+  if (job.status === "pending") {
+    return "Queued";
+  }
+  if (job.status === "completed") {
+    return "Completed";
+  }
+  if (job.status === "failed") {
+    return "Failed";
+  }
+  return job.phase.replaceAll("_", " ");
+}
+
+function formatProgressCount(processed: number, total?: number) {
+  return `${processed}/${total ?? "?"}`;
+}
+
+function progressPercent(job: ActiveJob) {
+  let total = 0;
+  let processed = 0;
+  if (job.totalFiles && job.totalFiles > 0) {
+    total = job.totalFiles;
+    processed = job.processedFiles;
+  } else if (job.totalChunks && job.totalChunks > 0) {
+    total = job.totalChunks;
+    processed = job.processedChunks;
+  }
+
+  if (job.status === "completed") {
+    return 100;
+  }
+  if (total <= 0) {
+    return job.status === "running" ? 12 : 0;
+  }
+  return Math.max(2, Math.min(100, Math.round((processed / total) * 100)));
+}
+
+function formatElapsed(startedAt?: string) {
+  if (!startedAt) {
+    return "unknown";
+  }
+  const started = Date.parse(startedAt);
+  if (Number.isNaN(started)) {
+    return "unknown";
+  }
+  const seconds = Math.max(0, Math.floor((Date.now() - started) / 1000));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function isJobStale(job: ActiveJob) {
+  const updatedAt = Date.parse(job.updatedAt);
+  if (Number.isNaN(updatedAt)) {
+    return false;
+  }
+  return Date.now() - updatedAt > 5 * 60 * 1000;
+}
+
 export function CodeIndexerDashboard() {
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
@@ -204,7 +289,8 @@ export function CodeIndexerDashboard() {
             if (
               next.has(repository.repoId) &&
               repository.status !== "queued" &&
-              repository.status !== "indexing"
+              repository.status !== "indexing" &&
+              !repository.activeJob
             ) {
               next.delete(repository.repoId);
             }
@@ -269,7 +355,9 @@ export function CodeIndexerDashboard() {
 
   const hasActiveIndexingJob = repositories.some(
     (repository) =>
-      repository.status === "queued" || repository.status === "indexing"
+      Boolean(repository.activeJob) ||
+      repository.status === "queued" ||
+      repository.status === "indexing"
   );
   const shouldPollRepositories =
     authState === "authenticated" &&
@@ -362,10 +450,15 @@ export function CodeIndexerDashboard() {
       )
     );
     try {
-      await apiRequest<null>(`/api/repositories/${encodeURIComponent(repoId)}/reindex`, {
+      const data = await apiRequest<{
+        job: QueuedIndexingJob;
+        status: "ok";
+      }>(`/api/repositories/${encodeURIComponent(repoId)}/reindex`, {
         method: "POST",
       });
-      setActionMessage("Reindex job queued. Refreshing status automatically.");
+      setActionMessage(
+        `Reindex job ${data.job.jobId} queued. Refreshing status automatically.`
+      );
       await loadRepositories(selectedInstallationId, { silent: true });
     } catch (err: unknown) {
       setReindexingRepoIds((current) => {
@@ -590,6 +683,68 @@ export function CodeIndexerDashboard() {
                       </div>
                     )}
                   </dl>
+                  {repository.activeJob && (
+                    <div className="code-indexer-progress">
+                      <div className="code-indexer-progress__heading">
+                        <strong>{activeJobLabel(repository.activeJob)}</strong>
+                        <span>{repository.activeJob.jobId}</span>
+                      </div>
+                      <div
+                        className="code-indexer-progress__bar"
+                        aria-label="Indexing progress"
+                      >
+                        <span
+                          className="code-indexer-progress__bar-fill"
+                          style={{
+                            width: `${progressPercent(repository.activeJob)}%`,
+                          }}
+                        />
+                      </div>
+                      <div className="code-indexer-progress__meta">
+                        <span>
+                          Files{" "}
+                          {formatProgressCount(
+                            repository.activeJob.processedFiles,
+                            repository.activeJob.totalFiles
+                          )}
+                        </span>
+                        <span>
+                          Chunks{" "}
+                          {formatProgressCount(
+                            repository.activeJob.processedChunks,
+                            repository.activeJob.totalChunks
+                          )}
+                        </span>
+                        <span>
+                          Elapsed{" "}
+                          {formatElapsed(
+                            repository.activeJob.startedAt ??
+                              repository.activeJob.createdAt
+                          )}
+                        </span>
+                      </div>
+                      {repository.activeJob.currentPath && (
+                        <p className="code-indexer-progress__path">
+                          {repository.activeJob.currentPath}
+                        </p>
+                      )}
+                      {repository.activeJob.message && (
+                        <p className="code-indexer-progress__message">
+                          {repository.activeJob.message}
+                        </p>
+                      )}
+                      {isJobStale(repository.activeJob) && (
+                        <p className="code-indexer-progress__warning">
+                          No progress update for more than 5 minutes.
+                        </p>
+                      )}
+                      {repository.activeJob.lastError && (
+                        <p className="code-indexer-progress__error">
+                          {repository.activeJob.lastError}
+                        </p>
+                      )}
+                    </div>
+                  )}
                   <Button
                     onClick={() => void handleReindex(repository.repoId)}
                     view="outlined"

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -63,6 +63,9 @@ type CreatedToken = {
 };
 
 type AuthState = "checking" | "authenticated" | "unauthenticated";
+type LoadRepositoriesOptions = {
+  silent?: boolean;
+};
 
 class DashboardApiError extends Error {
   readonly status: number;
@@ -167,25 +170,55 @@ export function CodeIndexerDashboard() {
   const [tokenName, setTokenName] = useState("Local coding agent");
   const [loading, setLoading] = useState(true);
   const [repositoriesLoading, setRepositoriesLoading] = useState(false);
+  const [reindexingRepoIds, setReindexingRepoIds] = useState<Set<string>>(
+    () => new Set()
+  );
   const [actionMessage, setActionMessage] = useState("");
   const [error, setError] = useState("");
 
-  const loadRepositories = useCallback(async (installationId: string) => {
-    if (!installationId) {
-      setRepositories([]);
-      return;
-    }
-    setRepositoriesLoading(true);
-    try {
-      const data = await apiRequest<{
-        repositories: Repository[];
-        status: "ok";
-      }>(`/api/repositories?installationId=${encodeURIComponent(installationId)}`);
-      setRepositories(data.repositories);
-    } finally {
-      setRepositoriesLoading(false);
-    }
-  }, []);
+  const loadRepositories = useCallback(
+    async (
+      installationId: string,
+      options: LoadRepositoriesOptions = {}
+    ) => {
+      if (!installationId) {
+        setRepositories([]);
+        return;
+      }
+      if (!options.silent) {
+        setRepositoriesLoading(true);
+      }
+      try {
+        const data = await apiRequest<{
+          repositories: Repository[];
+          status: "ok";
+        }>(
+          `/api/repositories?installationId=${encodeURIComponent(
+            installationId
+          )}`
+        );
+        setRepositories(data.repositories);
+        setReindexingRepoIds((current) => {
+          const next = new Set(current);
+          for (const repository of data.repositories) {
+            if (
+              next.has(repository.repoId) &&
+              repository.status !== "queued" &&
+              repository.status !== "indexing"
+            ) {
+              next.delete(repository.repoId);
+            }
+          }
+          return next;
+        });
+      } finally {
+        if (!options.silent) {
+          setRepositoriesLoading(false);
+        }
+      }
+    },
+    []
+  );
 
   const loadTokens = useCallback(async () => {
     const data = await apiRequest<{ status: "ok"; tokens: ApiToken[] }>("/api/tokens");
@@ -234,6 +267,29 @@ export function CodeIndexerDashboard() {
     void initialize();
   }, [initialize]);
 
+  const hasActiveIndexingJob = repositories.some(
+    (repository) =>
+      repository.status === "queued" || repository.status === "indexing"
+  );
+  const shouldPollRepositories =
+    authState === "authenticated" &&
+    Boolean(selectedInstallationId) &&
+    (hasActiveIndexingJob || reindexingRepoIds.size > 0);
+
+  useEffect(() => {
+    if (!shouldPollRepositories) {
+      return undefined;
+    }
+    const intervalId = window.setInterval(() => {
+      void loadRepositories(selectedInstallationId, { silent: true }).catch(
+        (err: unknown) => {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      );
+    }, 3000);
+    return () => window.clearInterval(intervalId);
+  }, [loadRepositories, selectedInstallationId, shouldPollRepositories]);
+
   const tokenForConfig = createdToken?.plaintextToken ?? "<token>";
   const mcpConfig = useMemo(
     () =>
@@ -266,6 +322,7 @@ export function CodeIndexerDashboard() {
     setSelectedInstallationId(installationId);
     setError("");
     setActionMessage("");
+    setReindexingRepoIds(new Set());
     try {
       await loadRepositories(installationId);
     } catch (err: unknown) {
@@ -296,13 +353,26 @@ export function CodeIndexerDashboard() {
   const handleReindex = async (repoId: string) => {
     setError("");
     setActionMessage("");
+    setReindexingRepoIds((current) => new Set(current).add(repoId));
+    setRepositories((current) =>
+      current.map((repository) =>
+        repository.repoId === repoId
+          ? { ...repository, status: "queued" }
+          : repository
+      )
+    );
     try {
       await apiRequest<null>(`/api/repositories/${encodeURIComponent(repoId)}/reindex`, {
         method: "POST",
       });
-      setActionMessage("Reindex job queued.");
-      await loadRepositories(selectedInstallationId);
+      setActionMessage("Reindex job queued. Refreshing status automatically.");
+      await loadRepositories(selectedInstallationId, { silent: true });
     } catch (err: unknown) {
+      setReindexingRepoIds((current) => {
+        const next = new Set(current);
+        next.delete(repoId);
+        return next;
+      });
       setError(err instanceof Error ? err.message : String(err));
     }
   };
@@ -477,6 +547,11 @@ export function CodeIndexerDashboard() {
             </div>
           ) : (
             <div className="code-indexer-dashboard__repo-list">
+              {shouldPollRepositories && (
+                <p className="code-indexer-dashboard__polling">
+                  Indexing is active. Repository status refreshes automatically.
+                </p>
+              )}
               {repositories.map((repository) => (
                 <article
                   className="code-indexer-dashboard__repo"
@@ -518,10 +593,17 @@ export function CodeIndexerDashboard() {
                   <Button
                     onClick={() => void handleReindex(repository.repoId)}
                     view="outlined"
-                    disabled={repository.status === "deleted"}
+                    disabled={
+                      repository.status === "deleted" ||
+                      repository.status === "queued" ||
+                      repository.status === "indexing" ||
+                      reindexingRepoIds.has(repository.repoId)
+                    }
                   >
                     <Icon data={ArrowRotateRight} size={16} />
-                    Reindex
+                    {reindexingRepoIds.has(repository.repoId)
+                      ? "Reindex queued"
+                      : "Reindex"}
                   </Button>
                 </article>
               ))}

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -22,6 +22,13 @@ import {
 } from "./CodeIndexerLanding";
 import "./CodeIndexer.scss";
 
+const MCP_AGENT_USAGE_PROMPT = `Use ydb-qdrant-code-indexer as searchable project memory for indexed GitHub repositories.
+If owner/repo is unknown, call list_repositories.
+In a local checkout, infer owner/repo from git remote, then call list_repository_indexes.
+Use the default branch index for general repository questions.
+For pull requests, pass prNumber to search_code.
+Call search_code with concise natural-language or code-oriented queries before answering repository-specific questions.`;
+
 type GitHubUser = {
   githubUserId: string;
   login: string;
@@ -41,11 +48,18 @@ type ActiveJob = {
   currentPath?: string;
   finishedAt?: string;
   jobId: string;
+  jobKind:
+    | "full-index"
+    | "incremental-push"
+    | "delete-repo-index"
+    | "pr-index"
+    | "delete-pr-index";
   lastError?: string;
   message?: string;
   phase: string;
   processedChunks: number;
   processedFiles: number;
+  prNumber?: number;
   startedAt?: string;
   status: "pending" | "running" | "completed" | "failed";
   totalChunks?: number;
@@ -57,6 +71,7 @@ type QueuedIndexingJob = Pick<ActiveJob, "jobId" | "phase" | "status">;
 
 type Repository = {
   activeJob?: ActiveJob;
+  activeJobs?: ActiveJob[];
   chunkCount?: number;
   defaultBranch: string;
   installationId: string;
@@ -180,16 +195,33 @@ function statusLabel(status: RepositoryStatus) {
 }
 
 function activeJobLabel(job: ActiveJob) {
+  let target = "Default branch reindex";
+  if (job.jobKind === "pr-index") {
+    target =
+      job.prNumber === undefined
+        ? "Pull request index"
+        : `Pull request #${job.prNumber} index`;
+  } else if (job.jobKind === "delete-pr-index") {
+    target =
+      job.prNumber === undefined
+        ? "Pull request cleanup"
+        : `Pull request #${job.prNumber} cleanup`;
+  } else if (job.jobKind === "incremental-push") {
+    target = "Default branch update";
+  } else if (job.jobKind === "delete-repo-index") {
+    target = "Repository cleanup";
+  }
+
   if (job.status === "pending") {
-    return "Queued";
+    return `${target} queued`;
   }
   if (job.status === "completed") {
-    return "Completed";
+    return `${target} completed`;
   }
   if (job.status === "failed") {
-    return "Failed";
+    return `${target} failed`;
   }
-  return job.phase.replaceAll("_", " ");
+  return `${target} · ${job.phase.replaceAll("_", " ")}`;
 }
 
 function formatProgressCount(processed: number, total?: number) {
@@ -244,6 +276,22 @@ function isJobStale(job: ActiveJob) {
   return Date.now() - updatedAt > 5 * 60 * 1000;
 }
 
+function repositoryActiveJobs(repository: Repository) {
+  if (repository.activeJobs && repository.activeJobs.length > 0) {
+    return repository.activeJobs;
+  }
+  return repository.activeJob ? [repository.activeJob] : [];
+}
+
+function hasActiveDefaultBranchJob(repository: Repository) {
+  return repositoryActiveJobs(repository).some(
+    (job) =>
+      job.jobKind === "full-index" ||
+      job.jobKind === "incremental-push" ||
+      job.jobKind === "delete-repo-index"
+  );
+}
+
 export function CodeIndexerDashboard() {
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [user, setUser] = useState<GitHubUser | null>(null);
@@ -290,7 +338,7 @@ export function CodeIndexerDashboard() {
               next.has(repository.repoId) &&
               repository.status !== "queued" &&
               repository.status !== "indexing" &&
-              !repository.activeJob
+              !hasActiveDefaultBranchJob(repository)
             ) {
               next.delete(repository.repoId);
             }
@@ -355,7 +403,7 @@ export function CodeIndexerDashboard() {
 
   const hasActiveIndexingJob = repositories.some(
     (repository) =>
-      Boolean(repository.activeJob) ||
+      repositoryActiveJobs(repository).length > 0 ||
       repository.status === "queued" ||
       repository.status === "indexing"
   );
@@ -645,123 +693,130 @@ export function CodeIndexerDashboard() {
                   Indexing is active. Repository status refreshes automatically.
                 </p>
               )}
-              {repositories.map((repository) => (
-                <article
-                  className="code-indexer-dashboard__repo"
-                  key={repository.repoId}
-                >
-                  <div className="code-indexer-dashboard__repo-main">
-                    <div>
-                      <h3>
-                        {repository.owner}/{repository.repo}
-                      </h3>
-                      <p>
-                        Branch {repository.defaultBranch} · SHA{" "}
-                        {shortSha(repository.lastIndexedSha)}
-                      </p>
-                    </div>
-                    <span
-                      className={`code-indexer-dashboard__status code-indexer-dashboard__status--${repository.status}`}
-                    >
-                      <Icon data={statusIcon(repository.status)} size={16} />
-                      {statusLabel(repository.status)}
-                    </span>
-                  </div>
-                  <dl className="code-indexer-dashboard__repo-meta">
-                    <div>
-                      <dt>Chunks</dt>
-                      <dd>{repository.chunkCount ?? 0}</dd>
-                    </div>
-                    <div>
-                      <dt>Last indexed</dt>
-                      <dd>{formatDate(repository.lastIndexedAt)}</dd>
-                    </div>
-                    {repository.lastError && (
+              {repositories.map((repository) => {
+                const activeJobs = repositoryActiveJobs(repository);
+                const defaultBranchJobActive =
+                  hasActiveDefaultBranchJob(repository);
+                return (
+                  <article
+                    className="code-indexer-dashboard__repo"
+                    key={repository.repoId}
+                  >
+                    <div className="code-indexer-dashboard__repo-main">
                       <div>
-                        <dt>Error</dt>
-                        <dd>{repository.lastError}</dd>
+                        <h3>
+                          {repository.owner}/{repository.repo}
+                        </h3>
+                        <p>
+                          Default branch {repository.defaultBranch} · SHA{" "}
+                          {shortSha(repository.lastIndexedSha)}
+                        </p>
+                      </div>
+                      <span
+                        className={`code-indexer-dashboard__status code-indexer-dashboard__status--${repository.status}`}
+                      >
+                        <Icon data={statusIcon(repository.status)} size={16} />
+                        {statusLabel(repository.status)}
+                      </span>
+                    </div>
+                    <dl className="code-indexer-dashboard__repo-meta">
+                      <div>
+                        <dt>Default branch chunks</dt>
+                        <dd>{repository.chunkCount ?? 0}</dd>
+                      </div>
+                      <div>
+                        <dt>Default branch indexed</dt>
+                        <dd>{formatDate(repository.lastIndexedAt)}</dd>
+                      </div>
+                      {repository.lastError && (
+                        <div>
+                          <dt>Default branch error</dt>
+                          <dd>{repository.lastError}</dd>
+                        </div>
+                      )}
+                    </dl>
+                    {activeJobs.length > 0 && (
+                      <div className="code-indexer-dashboard__job-list">
+                        {activeJobs.map((job) => (
+                          <div className="code-indexer-progress" key={job.jobId}>
+                            <div className="code-indexer-progress__heading">
+                              <strong>{activeJobLabel(job)}</strong>
+                              <span>{job.jobId}</span>
+                            </div>
+                            <div
+                              className="code-indexer-progress__bar"
+                              aria-label="Indexing progress"
+                            >
+                              <span
+                                className="code-indexer-progress__bar-fill"
+                                style={{
+                                  width: `${progressPercent(job)}%`,
+                                }}
+                              />
+                            </div>
+                            <div className="code-indexer-progress__meta">
+                              <span>
+                                Files{" "}
+                                {formatProgressCount(
+                                  job.processedFiles,
+                                  job.totalFiles
+                                )}
+                              </span>
+                              <span>
+                                Chunks{" "}
+                                {formatProgressCount(
+                                  job.processedChunks,
+                                  job.totalChunks
+                                )}
+                              </span>
+                              <span>
+                                Elapsed{" "}
+                                {formatElapsed(job.startedAt ?? job.createdAt)}
+                              </span>
+                            </div>
+                            {job.currentPath && (
+                              <p className="code-indexer-progress__path">
+                                {job.currentPath}
+                              </p>
+                            )}
+                            {job.message && (
+                              <p className="code-indexer-progress__message">
+                                {job.message}
+                              </p>
+                            )}
+                            {isJobStale(job) && (
+                              <p className="code-indexer-progress__warning">
+                                No progress update for more than 5 minutes.
+                              </p>
+                            )}
+                            {job.lastError && (
+                              <p className="code-indexer-progress__error">
+                                {job.lastError}
+                              </p>
+                            )}
+                          </div>
+                        ))}
                       </div>
                     )}
-                  </dl>
-                  {repository.activeJob && (
-                    <div className="code-indexer-progress">
-                      <div className="code-indexer-progress__heading">
-                        <strong>{activeJobLabel(repository.activeJob)}</strong>
-                        <span>{repository.activeJob.jobId}</span>
-                      </div>
-                      <div
-                        className="code-indexer-progress__bar"
-                        aria-label="Indexing progress"
-                      >
-                        <span
-                          className="code-indexer-progress__bar-fill"
-                          style={{
-                            width: `${progressPercent(repository.activeJob)}%`,
-                          }}
-                        />
-                      </div>
-                      <div className="code-indexer-progress__meta">
-                        <span>
-                          Files{" "}
-                          {formatProgressCount(
-                            repository.activeJob.processedFiles,
-                            repository.activeJob.totalFiles
-                          )}
-                        </span>
-                        <span>
-                          Chunks{" "}
-                          {formatProgressCount(
-                            repository.activeJob.processedChunks,
-                            repository.activeJob.totalChunks
-                          )}
-                        </span>
-                        <span>
-                          Elapsed{" "}
-                          {formatElapsed(
-                            repository.activeJob.startedAt ??
-                              repository.activeJob.createdAt
-                          )}
-                        </span>
-                      </div>
-                      {repository.activeJob.currentPath && (
-                        <p className="code-indexer-progress__path">
-                          {repository.activeJob.currentPath}
-                        </p>
-                      )}
-                      {repository.activeJob.message && (
-                        <p className="code-indexer-progress__message">
-                          {repository.activeJob.message}
-                        </p>
-                      )}
-                      {isJobStale(repository.activeJob) && (
-                        <p className="code-indexer-progress__warning">
-                          No progress update for more than 5 minutes.
-                        </p>
-                      )}
-                      {repository.activeJob.lastError && (
-                        <p className="code-indexer-progress__error">
-                          {repository.activeJob.lastError}
-                        </p>
-                      )}
-                    </div>
-                  )}
-                  <Button
-                    onClick={() => void handleReindex(repository.repoId)}
-                    view="outlined"
-                    disabled={
-                      repository.status === "deleted" ||
-                      repository.status === "queued" ||
-                      repository.status === "indexing" ||
-                      reindexingRepoIds.has(repository.repoId)
-                    }
-                  >
-                    <Icon data={ArrowRotateRight} size={16} />
-                    {reindexingRepoIds.has(repository.repoId)
-                      ? "Reindex queued"
-                      : "Reindex"}
-                  </Button>
-                </article>
-              ))}
+                    <Button
+                      onClick={() => void handleReindex(repository.repoId)}
+                      view="outlined"
+                      disabled={
+                        repository.status === "deleted" ||
+                        repository.status === "queued" ||
+                        repository.status === "indexing" ||
+                        defaultBranchJobActive ||
+                        reindexingRepoIds.has(repository.repoId)
+                      }
+                    >
+                      <Icon data={ArrowRotateRight} size={16} />
+                      {reindexingRepoIds.has(repository.repoId)
+                        ? "Reindex queued"
+                        : "Reindex default branch"}
+                    </Button>
+                  </article>
+                );
+              })}
             </div>
           )}
         </div>
@@ -846,6 +901,23 @@ export function CodeIndexerDashboard() {
               <Icon data={Copy} size={16} />
               Copy config
             </Button>
+            <div className="code-indexer-dashboard__agent-prompt">
+              <h3>Agent prompt</h3>
+              <p>
+                Add this to your agent instructions if the MCP client does not
+                show server instructions clearly.
+              </p>
+              <pre>{MCP_AGENT_USAGE_PROMPT}</pre>
+              <Button
+                onClick={() =>
+                  void copyText(MCP_AGENT_USAGE_PROMPT, "Agent prompt copied.")
+                }
+                view="outlined"
+              >
+                <Icon data={Copy} size={16} />
+                Copy prompt
+              </Button>
+            </div>
           </section>
 
           <section className="code-indexer-dashboard__panel code-indexer-dashboard__panel--danger">

--- a/src/components/CodeIndexer/CodeIndexerDashboard.tsx
+++ b/src/components/CodeIndexer/CodeIndexerDashboard.tsx
@@ -119,6 +119,10 @@ class DashboardApiError extends Error {
   }
 }
 
+function isUnauthorizedError(err: unknown) {
+  return err instanceof DashboardApiError && err.status === 401;
+}
+
 async function apiRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
   const headers = new Headers(options.headers);
   if (options.body && !headers.has("content-type")) {
@@ -268,6 +272,21 @@ export function CodeIndexerDashboard() {
   const [actionMessage, setActionMessage] = useState("");
   const [error, setError] = useState("");
 
+  const resetSession = useCallback((message = "") => {
+    repositoriesRequestId.current += 1;
+    setAuthState("unauthenticated");
+    setUser(null);
+    setInstallations([]);
+    setSelectedInstallationId("");
+    setRepositories([]);
+    setTokens([]);
+    setCreatedToken(null);
+    setReindexingRepoIds(new Set());
+    setActionMessage("");
+    setRepositoriesLoading(false);
+    setError(message);
+  }, []);
+
   const loadRepositories = useCallback(
     async (
       installationId: string,
@@ -355,8 +374,8 @@ export function CodeIndexerDashboard() {
         setRepositories([]);
       }
     } catch (err: unknown) {
-      if (err instanceof DashboardApiError && err.status === 401) {
-        setAuthState("unauthenticated");
+      if (isUnauthorizedError(err)) {
+        resetSession();
       } else {
         setAuthState("error");
         setError(err instanceof Error ? err.message : String(err));
@@ -364,7 +383,7 @@ export function CodeIndexerDashboard() {
     } finally {
       setLoading(false);
     }
-  }, [loadRepositories, loadTokens]);
+  }, [loadRepositories, loadTokens, resetSession]);
 
   useEffect(() => {
     void initialize();
@@ -388,11 +407,8 @@ export function CodeIndexerDashboard() {
     const intervalId = window.setInterval(() => {
       void loadRepositories(selectedInstallationId, { silent: true }).catch(
         (err: unknown) => {
-          if (err instanceof DashboardApiError && err.status === 401) {
-            setAuthState("unauthenticated");
-            setRepositories([]);
-            setReindexingRepoIds(new Set());
-            setError("Session expired. Sign in again.");
+          if (isUnauthorizedError(err)) {
+            resetSession("Session expired. Sign in again.");
             return;
           }
           setError(err instanceof Error ? err.message : String(err));
@@ -400,7 +416,7 @@ export function CodeIndexerDashboard() {
       );
     }, 3000);
     return () => window.clearInterval(intervalId);
-  }, [loadRepositories, selectedInstallationId, shouldPollRepositories]);
+  }, [loadRepositories, resetSession, selectedInstallationId, shouldPollRepositories]);
 
   const tokenForConfig = createdToken?.plaintextToken ?? "<token>";
   const mcpConfig = useMemo(
@@ -449,6 +465,10 @@ export function CodeIndexerDashboard() {
     try {
       await loadRepositories(installationId);
     } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
       setError(err instanceof Error ? err.message : String(err));
     }
   };
@@ -469,6 +489,10 @@ export function CodeIndexerDashboard() {
       setActionMessage("Token created. Copy it now; it will not be shown again.");
       await loadTokens();
     } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
       setError(err instanceof Error ? err.message : String(err));
     }
   };
@@ -496,6 +520,10 @@ export function CodeIndexerDashboard() {
       );
       await loadRepositories(selectedInstallationId, { silent: true });
     } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
       setReindexingRepoIds((current) => {
         const next = new Set(current);
         next.delete(repoId);
@@ -515,6 +543,10 @@ export function CodeIndexerDashboard() {
       setActionMessage("Token revoked.");
       await loadTokens();
     } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
       setError(err instanceof Error ? err.message : String(err));
     }
   };
@@ -523,11 +555,7 @@ export function CodeIndexerDashboard() {
     setError("");
     try {
       await apiRequest<null>("/api/logout", { method: "POST" });
-      setAuthState("unauthenticated");
-      setUser(null);
-      setInstallations([]);
-      setRepositories([]);
-      setTokens([]);
+      resetSession();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -549,12 +577,12 @@ export function CodeIndexerDashboard() {
         deletedRepositories: number;
         status: "ok";
       }>("/api/privacy/delete-my-data", { method: "POST" });
-      setAuthState("unauthenticated");
-      setUser(null);
-      setInstallations([]);
-      setRepositories([]);
-      setTokens([]);
+      resetSession();
     } catch (err: unknown) {
+      if (isUnauthorizedError(err)) {
+        resetSession("Session expired. Sign in again.");
+        return;
+      }
       setError(err instanceof Error ? err.message : String(err));
     }
   };

--- a/src/components/CodeIndexer/CodeIndexerInfoPage.tsx
+++ b/src/components/CodeIndexer/CodeIndexerInfoPage.tsx
@@ -43,7 +43,9 @@ export function CodeIndexerInfoPage({
             <Button
               href={action.href}
               key={action.href}
-              rel={action.href.startsWith("http") ? "noopener" : undefined}
+              rel={
+                action.href.startsWith("http") ? "noopener noreferrer" : undefined
+              }
               size="l"
               target={action.href.startsWith("http") ? "_blank" : undefined}
               view="action"

--- a/src/components/CodeIndexer/CodeIndexerInfoPage.tsx
+++ b/src/components/CodeIndexer/CodeIndexerInfoPage.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@gravity-ui/uikit";
+import "./CodeIndexer.scss";
+
+type InfoAction = {
+  href: string;
+  label: string;
+};
+
+type InfoSection = {
+  items: string[];
+  title: string;
+};
+
+type CodeIndexerInfoPageProps = {
+  actions?: InfoAction[];
+  eyebrow: string;
+  lead: string;
+  sections: InfoSection[];
+  title: string;
+};
+
+export function CodeIndexerInfoPage({
+  actions = [],
+  eyebrow,
+  lead,
+  sections,
+  title,
+}: CodeIndexerInfoPageProps) {
+  return (
+    <main className="code-indexer code-indexer-info">
+      <section className="code-indexer-info__hero">
+        <p className="code-indexer__eyebrow">{eyebrow}</p>
+        <h1>{title}</h1>
+        <p className="code-indexer__lead">{lead}</p>
+        <div className="code-indexer__actions">
+          <Button href="/code-indexer/" size="l" view="outlined">
+            Code Indexer home
+          </Button>
+          <Button href="/code-indexer/dashboard/" size="l" view="outlined">
+            Dashboard
+          </Button>
+          {actions.map((action) => (
+            <Button
+              href={action.href}
+              key={action.href}
+              rel={action.href.startsWith("http") ? "noopener" : undefined}
+              size="l"
+              target={action.href.startsWith("http") ? "_blank" : undefined}
+              view="action"
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      </section>
+
+      {sections.map((section) => (
+        <section className="code-indexer-info__section" key={section.title}>
+          <h2>{section.title}</h2>
+          <ul>
+            {section.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/components/CodeIndexer/CodeIndexerLanding.tsx
+++ b/src/components/CodeIndexer/CodeIndexerLanding.tsx
@@ -19,6 +19,29 @@ export const CODE_INDEXER_INSTALL_URL =
   "https://github.com/apps/ydb-qdrant-code-indexer/installations/new";
 export const CODE_INDEXER_DASHBOARD_PATH = "/code-indexer/dashboard/";
 
+type CodeIndexerHomePromoContent = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  cta: string;
+};
+
+export const codeIndexerHomePromoEn: CodeIndexerHomePromoContent = {
+  eyebrow: "New hosted app",
+  title: "YDB Qdrant Code Indexer",
+  body:
+    "Index GitHub repositories into YDB-backed Qdrant-compatible storage and give coding agents searchable project memory through hosted MCP.",
+  cta: "Open Code Indexer",
+};
+
+export const codeIndexerHomePromoRu: CodeIndexerHomePromoContent = {
+  eyebrow: "Новый hosted app",
+  title: "YDB Qdrant Code Indexer",
+  body:
+    "Индексируйте GitHub-репозитории в Qdrant-совместимое хранилище на YDB и давайте coding agents проектную память через hosted MCP.",
+  cta: "Открыть Code Indexer",
+};
+
 export function buildCodeIndexerLoginUrl(returnPath = CODE_INDEXER_DASHBOARD_PATH) {
   return `${CODE_INDEXER_BACKEND_URL}/github/oauth/start?return_to=${encodeURIComponent(
     returnPath
@@ -73,19 +96,20 @@ const trustItems: Feature[] = [
   },
 ];
 
-export function CodeIndexerHomePromo() {
+export function CodeIndexerHomePromo({
+  content = codeIndexerHomePromoEn,
+}: {
+  content?: CodeIndexerHomePromoContent;
+}) {
   return (
     <section className="code-indexer-promo" aria-labelledby="code-indexer-promo-title">
       <div>
-        <p className="code-indexer-promo__eyebrow">New hosted app</p>
-        <h2 id="code-indexer-promo-title">YDB Qdrant Code Indexer</h2>
-        <p>
-          Index GitHub repositories into YDB-backed Qdrant-compatible storage
-          and give coding agents searchable project memory through hosted MCP.
-        </p>
+        <p className="code-indexer-promo__eyebrow">{content.eyebrow}</p>
+        <h2 id="code-indexer-promo-title">{content.title}</h2>
+        <p>{content.body}</p>
       </div>
       <Button href="/code-indexer/" size="l" view="outlined">
-        Open Code Indexer
+        {content.cta}
         <Icon data={ArrowRight} size={16} />
       </Button>
     </section>

--- a/src/components/CodeIndexer/CodeIndexerLanding.tsx
+++ b/src/components/CodeIndexer/CodeIndexerLanding.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import { Button, Icon } from "@gravity-ui/uikit";
 import type { IconData } from "@gravity-ui/uikit";
@@ -132,7 +130,7 @@ export function CodeIndexerLanding() {
             <Button
               href={CODE_INDEXER_INSTALL_URL}
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
               size="xl"
               view="action"
             >
@@ -190,7 +188,7 @@ export function CodeIndexerLanding() {
           <p className="code-indexer__eyebrow">Public beta shape</p>
           <h2 id="code-indexer-trust">Built for narrow access and cost control</h2>
         </div>
-        <div className="code-indexer__feature-grid code-indexer__feature-grid--compact">
+        <div className="code-indexer__feature-grid">
           {trustItems.map((feature) => (
             <article className="code-indexer__feature" key={feature.title}>
               <Icon data={feature.icon} size={22} />

--- a/src/components/CodeIndexer/CodeIndexerLanding.tsx
+++ b/src/components/CodeIndexer/CodeIndexerLanding.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import Image from "next/image";
+import { Button, Icon } from "@gravity-ui/uikit";
+import type { IconData } from "@gravity-ui/uikit";
+import {
+  ArrowRight,
+  Code,
+  DatabaseMagnifier,
+  Key,
+  Rocket,
+  ShieldCheck,
+  Terminal,
+} from "@gravity-ui/icons";
+import "./CodeIndexer.scss";
+
+export const CODE_INDEXER_BACKEND_URL = "https://code-indexer.ydb-qdrant.tech";
+export const CODE_INDEXER_INSTALL_URL =
+  "https://github.com/apps/ydb-qdrant-code-indexer/installations/new";
+export const CODE_INDEXER_DASHBOARD_PATH = "/code-indexer/dashboard/";
+
+export function buildCodeIndexerLoginUrl(returnPath = CODE_INDEXER_DASHBOARD_PATH) {
+  return `${CODE_INDEXER_BACKEND_URL}/github/oauth/start?return_to=${encodeURIComponent(
+    returnPath
+  )}`;
+}
+
+type Feature = {
+  description: string;
+  icon: IconData;
+  title: string;
+};
+
+const landingFeatures: Feature[] = [
+  {
+    description:
+      "The GitHub App receives repository webhooks and refreshes code chunks after pushes and pull requests.",
+    icon: Code,
+    title: "Repository aware",
+  },
+  {
+    description:
+      "Chunks, embeddings, GitHub metadata, and search payloads live in YDB-backed Qdrant-compatible storage.",
+    icon: DatabaseMagnifier,
+    title: "Vector memory on YDB",
+  },
+  {
+    description:
+      "Coding agents call one hosted MCP endpoint and search by owner, repository, and natural language query.",
+    icon: Terminal,
+    title: "Agent ready MCP",
+  },
+];
+
+const trustItems: Feature[] = [
+  {
+    description:
+      "GitHub permissions are scoped to metadata, contents, pull requests, and checks for installed repositories.",
+    icon: ShieldCheck,
+    title: "Least privilege",
+  },
+  {
+    description:
+      "MCP tokens are shown once, stored as hashes, and can be revoked from the dashboard.",
+    icon: Key,
+    title: "Token control",
+  },
+  {
+    description:
+      "Public beta quotas limit repository count, indexed chunks, and daily searches.",
+    icon: Rocket,
+    title: "Hosted beta",
+  },
+];
+
+export function CodeIndexerHomePromo() {
+  return (
+    <section className="code-indexer-promo" aria-labelledby="code-indexer-promo-title">
+      <div>
+        <p className="code-indexer-promo__eyebrow">New hosted app</p>
+        <h2 id="code-indexer-promo-title">YDB Qdrant Code Indexer</h2>
+        <p>
+          Index GitHub repositories into YDB-backed Qdrant-compatible storage
+          and give coding agents searchable project memory through hosted MCP.
+        </p>
+      </div>
+      <Button href="/code-indexer/" size="l" view="outlined">
+        Open Code Indexer
+        <Icon data={ArrowRight} size={16} />
+      </Button>
+    </section>
+  );
+}
+
+export function CodeIndexerLanding() {
+  return (
+    <main className="code-indexer">
+      <section className="code-indexer__hero" aria-labelledby="code-indexer-title">
+        <div className="code-indexer__hero-copy">
+          <p className="code-indexer__eyebrow">GitHub App for coding agents</p>
+          <h1 id="code-indexer-title">YDB Qdrant Code Indexer</h1>
+          <p className="code-indexer__lead">
+            Install a GitHub App, index repositories into YDB-backed
+            Qdrant-compatible storage, and give your coding agents searchable
+            project memory.
+          </p>
+          <div className="code-indexer__actions">
+            <Button
+              href={CODE_INDEXER_INSTALL_URL}
+              target="_blank"
+              rel="noopener"
+              size="xl"
+              view="action"
+            >
+              Install GitHub App
+              <Icon data={ArrowRight} size={18} />
+            </Button>
+            <Button href={buildCodeIndexerLoginUrl()} size="xl" view="outlined">
+              Open dashboard
+            </Button>
+          </div>
+        </div>
+        <div className="code-indexer__hero-visual" aria-hidden="true">
+          <Image
+            src="/assets/preview.png"
+            alt=""
+            width={1024}
+            height={1024}
+            className="code-indexer__hero-image"
+            priority
+            unoptimized
+          />
+          <div className="code-indexer__terminal">
+            <div className="code-indexer__terminal-bar">
+              <span />
+              <span />
+              <span />
+            </div>
+            <pre>{`search_code({
+  owner: "astandrik",
+  repo: "local-ydb-toolkit",
+  query: "tenant bootstrap flow"
+})`}</pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="code-indexer__section" aria-labelledby="code-indexer-flow">
+        <div className="code-indexer__section-heading">
+          <p className="code-indexer__eyebrow">How it works</p>
+          <h2 id="code-indexer-flow">From repository events to searchable memory</h2>
+        </div>
+        <div className="code-indexer__feature-grid">
+          {landingFeatures.map((feature) => (
+            <article className="code-indexer__feature" key={feature.title}>
+              <Icon data={feature.icon} size={22} />
+              <h3>{feature.title}</h3>
+              <p>{feature.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="code-indexer__section" aria-labelledby="code-indexer-trust">
+        <div className="code-indexer__section-heading">
+          <p className="code-indexer__eyebrow">Public beta shape</p>
+          <h2 id="code-indexer-trust">Built for narrow access and cost control</h2>
+        </div>
+        <div className="code-indexer__feature-grid code-indexer__feature-grid--compact">
+          {trustItems.map((feature) => (
+            <article className="code-indexer__feature" key={feature.title}>
+              <Icon data={feature.icon} size={22} />
+              <h3>{feature.title}</h3>
+              <p>{feature.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/CodeIndexer/utils.ts
+++ b/src/components/CodeIndexer/utils.ts
@@ -1,0 +1,71 @@
+type ProgressJob = {
+  processedChunks: number;
+  processedFiles: number;
+  status: "pending" | "running" | "completed" | "failed";
+  totalChunks?: number;
+  totalFiles?: number;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseJsonBody(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function readApiError(value: unknown, fallback = "request failed") {
+  if (isRecord(value) && typeof value.error === "string") {
+    return value.error;
+  }
+  return fallback;
+}
+
+export function formatDate(value?: string) {
+  if (!value) {
+    return "Never";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString("en-US", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function shortSha(value?: string) {
+  return value ? value.slice(0, 12) : "n/a";
+}
+
+export function progressPercent(job: ProgressJob) {
+  let total = 0;
+  let processed = 0;
+  if (job.totalFiles && job.totalFiles > 0) {
+    total = job.totalFiles;
+    processed = job.processedFiles;
+  } else if (job.totalChunks && job.totalChunks > 0) {
+    total = job.totalChunks;
+    processed = job.processedChunks;
+  }
+
+  if (job.status === "completed") {
+    return 100;
+  }
+  if (total <= 0) {
+    return job.status === "running" ? 12 : 0;
+  }
+  return Math.max(2, Math.min(100, Math.round((processed / total) * 100)));
+}

--- a/src/components/Footer.scss
+++ b/src/components/Footer.scss
@@ -16,6 +16,30 @@
     padding: var(--spacing-4xl) var(--spacing-xl);
   }
 
+  &__nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+    justify-content: center;
+    margin-bottom: var(--spacing-lg);
+  }
+
+  &__nav-link {
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 13px;
+    text-decoration: none;
+
+    @include hover {
+      color: var(--acc);
+      text-decoration: underline;
+    }
+
+    &:active {
+      color: var(--acc);
+      text-decoration: underline;
+    }
+  }
+
   &__text {
     margin: 0;
     font-size: 12px;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,6 +7,20 @@ import "./Footer.scss";
 export default function Footer() {
   return (
     <footer className="footer">
+      <nav className="footer__nav" aria-label="Code Indexer links">
+        <a href="/code-indexer/" className="footer__nav-link">
+          Code Indexer
+        </a>
+        <a href="/code-indexer/privacy/" className="footer__nav-link">
+          Privacy
+        </a>
+        <a href="/code-indexer/support/" className="footer__nav-link">
+          Support
+        </a>
+        <a href="/code-indexer/status/" className="footer__nav-link">
+          Status
+        </a>
+      </nav>
       <p className="footer__text">
         Created with{" "}
         <a
@@ -18,9 +32,7 @@ export default function Footer() {
             trackGoal("github_uikit_click", { source: "footer" })
           }
         >
-          <span>
-            gravity-ui/uikit
-          </span>
+          <span>gravity-ui/uikit</span>
           <Image
             src="/assets/gravity-ui-favicon.png"
             alt="Gravity UI"

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -13,6 +13,7 @@ export type HeroContent = {
   primaryCtaLabel: string;
   secondaryCtaLabel: string;
   docsLabel: string;
+  codeIndexerLabel: string;
   demoPrefix: string;
   demoButtonLabel: string;
   footnote: string;
@@ -76,6 +77,13 @@ export const HeroSectionBase = ({
           onClick={() => trackGoal("hero_docs_click")}
         >
           {content.docsLabel}
+        </Link>
+        <Link
+          id="hero-code-indexer-link"
+          href="/code-indexer/"
+          onClick={() => trackGoal("hero_code_indexer_click")}
+        >
+          {content.codeIndexerLabel}
         </Link>
       </div>
       <DemoEndpointBadge

--- a/src/components/HeroSection/locales.ts
+++ b/src/components/HeroSection/locales.ts
@@ -9,6 +9,7 @@ export const heroSectionEnContent: HeroContent = {
   primaryCtaLabel: "Get Started",
   secondaryCtaLabel: "Explore on GitHub",
   docsLabel: "Architecture & diagrams →",
+  codeIndexerLabel: "Code Indexer →",
   demoPrefix: "Public demo Qdrant base URL:",
   demoButtonLabel: "Copy",
   footnote:
@@ -22,6 +23,7 @@ export const heroSectionRuContent: HeroContent = {
   primaryCtaLabel: "Быстрый старт",
   secondaryCtaLabel: "Изучить на GitHub",
   docsLabel: "Архитектура и диаграммы →",
+  codeIndexerLabel: "Code Indexer →",
   demoPrefix: "Публичный demo‑endpoint:",
   demoButtonLabel: "Копировать",
   footnote:


### PR DESCRIPTION
Adds the Code Indexer public landing pages, dashboard/admin UI, sitemap/robots entries, and public policy/status/support pages.\n\nVerification:\n- npm run lint\n- npm run build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Code Indexer public site: a landing page, user dashboard, read-only admin dashboard, and static info pages (privacy, support, status), along with sitemap/robots entries and footer navigation links. Shared utilities (`utils.ts`) are properly extracted so both dashboard components draw on a single source of truth for formatting helpers.

- **User dashboard** (`CodeIndexerDashboard.tsx`) handles GitHub OAuth, per-installation repository listing with live polling, MCP token lifecycle, and a separated `handleReindex` error path (previous review items addressed). One handler — `handleLogout` — is missing the 401 guard present on every other mutating handler, leaving users stranded on the UI when their session has expired before they click the button.
- **Admin dashboard** (`CodeIndexerAdminDashboard.tsx`) provides a read-only global view with debounced search, filter dropdowns, and auto-polling tied to active-job count; utility functions are correctly shared from `utils.ts`.
- **Static pages and routing** (sitemap, robots, privacy, support, status) look correct: dashboard and admin paths are excluded from crawlers, external links use `rel=\"noopener noreferrer\"`, and all canonical URLs are set.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the logout 401 edge case addressed — the rest of the change is well-structured with correct polling guards, separated error scopes, and proper robots/sitemap configuration.

The logout handler silently swallows a 401 response without resetting the session, leaving a user whose session expired mid-visit stuck on the authenticated dashboard. Every other mutating handler in the same component already handles this case. All other parts of the PR — admin dashboard, info pages, sitemap, robots, utility extraction — look correct.

src/components/CodeIndexer/CodeIndexerDashboard.tsx — specifically the `handleLogout` function around line 629.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/CodeIndexer/CodeIndexerDashboard.tsx | Full user dashboard with auth, repo polling, token management, and reindex flow; `handleLogout` is missing the `isUnauthorizedError` guard that every other mutating handler uses, leaving users stuck on the UI when their session has expired. |
| src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx | Read-only admin view with debounced search, filter dropdowns, and auto-polling; `activeJobs(repository)` is called twice per table row but this is a minor inefficiency only. |
| src/components/CodeIndexer/utils.ts | Shared utility module extracted from both dashboards; correctly provides `formatDate`, `shortSha`, `progressPercent`, `readApiError`, `parseJsonBody`, and `isRecord`. |
| src/components/CodeIndexer/CodeIndexerLanding.tsx | Landing page and home-promo component; exports backend URL constants, login URL builder, and locale strings used by both dashboards and the home page. |
| src/components/CodeIndexer/CodeIndexerInfoPage.tsx | Shared layout for privacy/support/status static pages; correctly applies `rel="noopener noreferrer"` and `target="_blank"` only for external hrefs. |
| src/app/robots.ts | Correctly disallows `/code-indexer/dashboard/` and `/code-indexer/admin/` from crawlers while allowing all other paths. |
| src/app/sitemap.ts | Adds public code-indexer routes (landing, privacy, support, status) to the sitemap; correctly excludes dashboard and admin pages. |
| src/components/Footer.tsx | Footer reworked to add Code Indexer nav links; correctly retains `"use client"` for the analytics `onClick` handler. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Dashboard as CodeIndexerDashboard
    participant Backend as code-indexer.ydb-qdrant.tech

    Browser->>Dashboard: mount
    Dashboard->>Backend: GET /api/me
    Dashboard->>Backend: GET /api/installations
    Dashboard->>Backend: GET /api/tokens
    Dashboard->>Backend: "GET /api/repositories?installationId=..."
    Backend-->>Dashboard: repos + jobs state

    loop Poll every 3s (while active jobs)
        Dashboard->>Backend: GET /api/repositories (silent)
        Backend-->>Dashboard: updated status
    end

    Browser->>Dashboard: click Reindex
    Dashboard->>Backend: POST /api/repositories/:id/reindex
    Backend-->>Dashboard: job queued
    Dashboard->>Backend: GET /api/repositories (silent refresh)

    Browser->>Dashboard: click Logout
    Dashboard->>Backend: POST /api/logout
    alt 401 (session already expired)
        Backend-->>Dashboard: 401 error shown, UI stuck
    else 200
        Backend-->>Dashboard: resetSession, sign-in view
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx`, line 1449-1461 ([link](https://github.com/astandrik/ydb-qdrant-ui/blob/78310d2d3b3511ead1390e1b9954e6688912b9e1/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx#L1449-L1461)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Every keystroke fires three simultaneous admin API requests**

   `query` is listed as a dependency of `loadAdminData` (via `useCallback`), and `loadAdminData` is the sole dependency of the main `useEffect`. As a result, each character typed into the search `TextInput` immediately recreates `loadAdminData` and triggers a new round of `/api/admin/overview`, `/api/admin/repositories`, and `/api/admin/jobs` requests. Under normal use this creates rapid-fire bursts of three concurrent requests per keystroke, which hammers the admin backend and may also display stale-then-updated results out of order as responses race each other.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
   Line: 1449-1461

   Comment:
   **Every keystroke fires three simultaneous admin API requests**

   `query` is listed as a dependency of `loadAdminData` (via `useCallback`), and `loadAdminData` is the sole dependency of the main `useEffect`. As a result, each character typed into the search `TextInput` immediately recreates `loadAdminData` and triggers a new round of `/api/admin/overview`, `/api/admin/repositories`, and `/api/admin/jobs` requests. Under normal use this creates rapid-fire bursts of three concurrent requests per keystroke, which hammers the admin backend and may also display stale-then-updated results out of order as responses race each other.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Fydb-qdrant-ui%22%20on%20the%20existing%20branch%20%22code-indexer-public-site%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22code-indexer-public-site%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FCodeIndexer%2FCodeIndexerAdminDashboard.tsx%0ALine%3A%201449-1461%0A%0AComment%3A%0A**Every%20keystroke%20fires%20three%20simultaneous%20admin%20API%20requests**%0A%0A%60query%60%20is%20listed%20as%20a%20dependency%20of%20%60loadAdminData%60%20%28via%20%60useCallback%60%29%2C%20and%20%60loadAdminData%60%20is%20the%20sole%20dependency%20of%20the%20main%20%60useEffect%60.%20As%20a%20result%2C%20each%20character%20typed%20into%20the%20search%20%60TextInput%60%20immediately%20recreates%20%60loadAdminData%60%20and%20triggers%20a%20new%20round%20of%20%60%2Fapi%2Fadmin%2Foverview%60%2C%20%60%2Fapi%2Fadmin%2Frepositories%60%2C%20and%20%60%2Fapi%2Fadmin%2Fjobs%60%20requests.%20Under%20normal%20use%20this%20creates%20rapid-fire%20bursts%20of%20three%20concurrent%20requests%20per%20keystroke%2C%20which%20hammers%20the%20admin%20backend%20and%20may%20also%20display%20stale-then-updated%20results%20out%20of%20order%20as%20responses%20race%20each%20other.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FCodeIndexer%2FCodeIndexerAdminDashboard.tsx%0ALine%3A%201449-1461%0A%0AComment%3A%0A**Every%20keystroke%20fires%20three%20simultaneous%20admin%20API%20requests**%0A%0A%60query%60%20is%20listed%20as%20a%20dependency%20of%20%60loadAdminData%60%20%28via%20%60useCallback%60%29%2C%20and%20%60loadAdminData%60%20is%20the%20sole%20dependency%20of%20the%20main%20%60useEffect%60.%20As%20a%20result%2C%20each%20character%20typed%20into%20the%20search%20%60TextInput%60%20immediately%20recreates%20%60loadAdminData%60%20and%20triggers%20a%20new%20round%20of%20%60%2Fapi%2Fadmin%2Foverview%60%2C%20%60%2Fapi%2Fadmin%2Frepositories%60%2C%20and%20%60%2Fapi%2Fadmin%2Fjobs%60%20requests.%20Under%20normal%20use%20this%20creates%20rapid-fire%20bursts%20of%20three%20concurrent%20requests%20per%20keystroke%2C%20which%20hammers%20the%20admin%20backend%20and%20may%20also%20display%20stale-then-updated%20results%20out%20of%20order%20as%20responses%20race%20each%20other.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=astandrik%2Fydb-qdrant-ui&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx`, line 1263-1284 ([link](https://github.com/astandrik/ydb-qdrant-ui/blob/78310d2d3b3511ead1390e1b9954e6688912b9e1/src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx#L1263-L1284)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Utility functions duplicated between both dashboard components**

   `isRecord`, `readApiError`, `formatDate`, `shortSha`, and `progressPercent` are all defined identically (or near-identically) in both `CodeIndexerAdminDashboard.tsx` and `CodeIndexerDashboard.tsx`. The project rule says to remove duplicate implementations and share existing utilities consistently. Extracting these into a shared `src/components/CodeIndexer/utils.ts` module would eliminate the duplication and make future changes (e.g., locale-aware date formatting) apply everywhere.

   **Rule Used:** Remove unused interfaces and CSS classes that are ... ([source](https://app.greptile.com/review/custom-context?memory=dfecc753-e772-4407-a8fa-d7334788fb5a))
   
   **Learned From**
   [ydb-platform/ydb-embedded-ui#2729](https://github.com/ydb-platform/ydb-embedded-ui/pull/2729)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx
   Line: 1263-1284
   
   Comment:
   **Utility functions duplicated between both dashboard components**
   
   `isRecord`, `readApiError`, `formatDate`, `shortSha`, and `progressPercent` are all defined identically (or near-identically) in both `CodeIndexerAdminDashboard.tsx` and `CodeIndexerDashboard.tsx`. The project rule says to remove duplicate implementations and share existing utilities consistently. Extracting these into a shared `src/components/CodeIndexer/utils.ts` module would eliminate the duplication and make future changes (e.g., locale-aware date formatting) apply everywhere.
   
   **Rule Used:** Remove unused interfaces and CSS classes that are ... ([source](https://app.greptile.com/review/custom-context?memory=dfecc753-e772-4407-a8fa-d7334788fb5a))
   
   **Learned From**
   [ydb-platform/ydb-embedded-ui#2729](https://github.com/ydb-platform/ydb-embedded-ui/pull/2729)
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Fydb-qdrant-ui%22%20on%20the%20existing%20branch%20%22code-indexer-public-site%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22code-indexer-public-site%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FCodeIndexer%2FCodeIndexerAdminDashboard.tsx%0ALine%3A%201263-1284%0A%0AComment%3A%0A**Utility%20functions%20duplicated%20between%20both%20dashboard%20components**%0A%0A%60isRecord%60%2C%20%60readApiError%60%2C%20%60formatDate%60%2C%20%60shortSha%60%2C%20and%20%60progressPercent%60%20are%20all%20defined%20identically%20%28or%20near-identically%29%20in%20both%20%60CodeIndexerAdminDashboard.tsx%60%20and%20%60CodeIndexerDashboard.tsx%60.%20The%20project%20rule%20says%20to%20remove%20duplicate%20implementations%20and%20share%20existing%20utilities%20consistently.%20Extracting%20these%20into%20a%20shared%20%60src%2Fcomponents%2FCodeIndexer%2Futils.ts%60%20module%20would%20eliminate%20the%20duplication%20and%20make%20future%20changes%20%28e.g.%2C%20locale-aware%20date%20formatting%29%20apply%20everywhere.%0A%0A**Rule%20Used%3A**%20Remove%20unused%20interfaces%20and%20CSS%20classes%20that%20are%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Ddfecc753-e772-4407-a8fa-d7334788fb5a%29%29%0A%0A**Learned%20From**%0A%5Bydb-platform%2Fydb-embedded-ui%232729%5D%28https%3A%2F%2Fgithub.com%2Fydb-platform%2Fydb-embedded-ui%2Fpull%2F2729%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FCodeIndexer%2FCodeIndexerAdminDashboard.tsx%0ALine%3A%201263-1284%0A%0AComment%3A%0A**Utility%20functions%20duplicated%20between%20both%20dashboard%20components**%0A%0A%60isRecord%60%2C%20%60readApiError%60%2C%20%60formatDate%60%2C%20%60shortSha%60%2C%20and%20%60progressPercent%60%20are%20all%20defined%20identically%20%28or%20near-identically%29%20in%20both%20%60CodeIndexerAdminDashboard.tsx%60%20and%20%60CodeIndexerDashboard.tsx%60.%20The%20project%20rule%20says%20to%20remove%20duplicate%20implementations%20and%20share%20existing%20utilities%20consistently.%20Extracting%20these%20into%20a%20shared%20%60src%2Fcomponents%2FCodeIndexer%2Futils.ts%60%20module%20would%20eliminate%20the%20duplication%20and%20make%20future%20changes%20%28e.g.%2C%20locale-aware%20date%20formatting%29%20apply%20everywhere.%0A%0A**Rule%20Used%3A**%20Remove%20unused%20interfaces%20and%20CSS%20classes%20that%20are%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Ddfecc753-e772-4407-a8fa-d7334788fb5a%29%29%0A%0A**Learned%20From**%0A%5Bydb-platform%2Fydb-embedded-ui%232729%5D%28https%3A%2F%2Fgithub.com%2Fydb-platform%2Fydb-embedded-ui%2Fpull%2F2729%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=astandrik%2Fydb-qdrant-ui&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `src/components/CodeIndexer/CodeIndexerDashboard.tsx`, line 2251-2281 ([link](https://github.com/astandrik/ydb-qdrant-ui/blob/30a1a3a27b2e025cdc3fa6925282877e2c135bee/src/components/CodeIndexer/CodeIndexerDashboard.tsx#L2251-L2281)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reindex button stays disabled after an API failure**

   `repository.status` is optimistically set to `"queued"` before the API call, but it is never reverted when the call throws. The `disabled` prop on the reindex button checks `repository.status === "queued"`, so after a failed request the button remains permanently disabled. The 3-second polling interval does eventually correct the status (because `hasActiveIndexingJob` stays true while status is `"queued"`), but during that window the user sees an error message yet cannot retry — they must wait for the next poll cycle to re-enable the button.

   The fix is to save the previous status before the optimistic update and restore it in the `catch` block.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/CodeIndexer/CodeIndexerDashboard.tsx
   Line: 2251-2281

   Comment:
   **Reindex button stays disabled after an API failure**

   `repository.status` is optimistically set to `"queued"` before the API call, but it is never reverted when the call throws. The `disabled` prop on the reindex button checks `repository.status === "queued"`, so after a failed request the button remains permanently disabled. The 3-second polling interval does eventually correct the status (because `hasActiveIndexingJob` stays true while status is `"queued"`), but during that window the user sees an error message yet cannot retry — they must wait for the next poll cycle to re-enable the button.

   The fix is to save the previous status before the optimistic update and restore it in the `catch` block.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Fydb-qdrant-ui%22%20on%20the%20existing%20branch%20%22code-indexer-public-site%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22code-indexer-public-site%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FCodeIndexer%2FCodeIndexerDashboard.tsx%0ALine%3A%202251-2281%0A%0AComment%3A%0A**Reindex%20button%20stays%20disabled%20after%20an%20API%20failure**%0A%0A%60repository.status%60%20is%20optimistically%20set%20to%20%60%22queued%22%60%20before%20the%20API%20call%2C%20but%20it%20is%20never%20reverted%20when%20the%20call%20throws.%20The%20%60disabled%60%20prop%20on%20the%20reindex%20button%20checks%20%60repository.status%20%3D%3D%3D%20%22queued%22%60%2C%20so%20after%20a%20failed%20request%20the%20button%20remains%20permanently%20disabled.%20The%203-second%20polling%20interval%20does%20eventually%20correct%20the%20status%20%28because%20%60hasActiveIndexingJob%60%20stays%20true%20while%20status%20is%20%60%22queued%22%60%29%2C%20but%20during%20that%20window%20the%20user%20sees%20an%20error%20message%20yet%20cannot%20retry%20%E2%80%94%20they%20must%20wait%20for%20the%20next%20poll%20cycle%20to%20re-enable%20the%20button.%0A%0AThe%20fix%20is%20to%20save%20the%20previous%20status%20before%20the%20optimistic%20update%20and%20restore%20it%20in%20the%20%60catch%60%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FCodeIndexer%2FCodeIndexerDashboard.tsx%0ALine%3A%202251-2281%0A%0AComment%3A%0A**Reindex%20button%20stays%20disabled%20after%20an%20API%20failure**%0A%0A%60repository.status%60%20is%20optimistically%20set%20to%20%60%22queued%22%60%20before%20the%20API%20call%2C%20but%20it%20is%20never%20reverted%20when%20the%20call%20throws.%20The%20%60disabled%60%20prop%20on%20the%20reindex%20button%20checks%20%60repository.status%20%3D%3D%3D%20%22queued%22%60%2C%20so%20after%20a%20failed%20request%20the%20button%20remains%20permanently%20disabled.%20The%203-second%20polling%20interval%20does%20eventually%20correct%20the%20status%20%28because%20%60hasActiveIndexingJob%60%20stays%20true%20while%20status%20is%20%60%22queued%22%60%29%2C%20but%20during%20that%20window%20the%20user%20sees%20an%20error%20message%20yet%20cannot%20retry%20%E2%80%94%20they%20must%20wait%20for%20the%20next%20poll%20cycle%20to%20re-enable%20the%20button.%0A%0AThe%20fix%20is%20to%20save%20the%20previous%20status%20before%20the%20optimistic%20update%20and%20restore%20it%20in%20the%20%60catch%60%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=astandrik%2Fydb-qdrant-ui&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Fydb-qdrant-ui%22%20on%20the%20existing%20branch%20%22code-indexer-public-site%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22code-indexer-public-site%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomponents%2FCodeIndexer%2FCodeIndexerDashboard.tsx%3A629-637%0A**%60handleLogout%60%20leaves%20the%20user%20stuck%20when%20the%20session%20has%20already%20expired**%0A%0AEvery%20other%20mutating%20handler%20in%20this%20component%20%28%60handleCreateToken%60%2C%20%60handleReindex%60%2C%20%60handleRevokeToken%60%2C%20%60handleDeleteMyData%60%29%20checks%20%60isUnauthorizedError%28err%29%60%20and%20calls%20%60resetSession%28...%29%60.%20%60handleLogout%60%20does%20not.%20If%20the%20user's%20session%20expires%20before%20they%20click%20logout%2C%20the%20%60POST%20%2Fapi%2Flogout%60%20returns%20%60401%60%2C%20the%20catch%20block%20sets%20an%20error%20message%2C%20and%20the%20user%20stays%20on%20the%20authenticated%20dashboard%20with%20no%20way%20to%20re-enter%20the%20sign-in%20flow%20without%20a%20full%20page%20refresh.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcomponents%2FCodeIndexer%2FCodeIndexerAdminDashboard.tsx%3A539-544%0A%60activeJobs%28repository%29%60%20is%20called%20twice%20per%20row%20%E2%80%94%20once%20to%20check%20%60.length%60%20and%20once%20to%20%60.map%28%29%60.%20Caching%20the%20result%20in%20a%20variable%20avoids%20the%20double%20call%20on%20every%20render%20of%20the%20table.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Ctd%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20jobs%20%3D%20activeJobs%28repository%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20jobs.length%20%3D%3D%3D%200%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%3ENone%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22code-indexer-admin__job-stack%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bjobs.map%28%28job%29%20%3D%3E%20%28%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomponents%2FCodeIndexer%2FCodeIndexerDashboard.tsx%3A629-637%0A**%60handleLogout%60%20leaves%20the%20user%20stuck%20when%20the%20session%20has%20already%20expired**%0A%0AEvery%20other%20mutating%20handler%20in%20this%20component%20%28%60handleCreateToken%60%2C%20%60handleReindex%60%2C%20%60handleRevokeToken%60%2C%20%60handleDeleteMyData%60%29%20checks%20%60isUnauthorizedError%28err%29%60%20and%20calls%20%60resetSession%28...%29%60.%20%60handleLogout%60%20does%20not.%20If%20the%20user's%20session%20expires%20before%20they%20click%20logout%2C%20the%20%60POST%20%2Fapi%2Flogout%60%20returns%20%60401%60%2C%20the%20catch%20block%20sets%20an%20error%20message%2C%20and%20the%20user%20stays%20on%20the%20authenticated%20dashboard%20with%20no%20way%20to%20re-enter%20the%20sign-in%20flow%20without%20a%20full%20page%20refresh.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcomponents%2FCodeIndexer%2FCodeIndexerAdminDashboard.tsx%3A539-544%0A%60activeJobs%28repository%29%60%20is%20called%20twice%20per%20row%20%E2%80%94%20once%20to%20check%20%60.length%60%20and%20once%20to%20%60.map%28%29%60.%20Caching%20the%20result%20in%20a%20variable%20avoids%20the%20double%20call%20on%20every%20render%20of%20the%20table.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Ctd%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20jobs%20%3D%20activeJobs%28repository%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20jobs.length%20%3D%3D%3D%200%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%3ENone%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22code-indexer-admin__job-stack%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bjobs.map%28%28job%29%20%3D%3E%20%28%0A%60%60%60%0A%0A&repo=astandrik%2Fydb-qdrant-ui&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/components/CodeIndexer/CodeIndexerDashboard.tsx:629-637
**`handleLogout` leaves the user stuck when the session has already expired**

Every other mutating handler in this component (`handleCreateToken`, `handleReindex`, `handleRevokeToken`, `handleDeleteMyData`) checks `isUnauthorizedError(err)` and calls `resetSession(...)`. `handleLogout` does not. If the user's session expires before they click logout, the `POST /api/logout` returns `401`, the catch block sets an error message, and the user stays on the authenticated dashboard with no way to re-enter the sign-in flow without a full page refresh.

### Issue 2 of 2
src/components/CodeIndexer/CodeIndexerAdminDashboard.tsx:539-544
`activeJobs(repository)` is called twice per row — once to check `.length` and once to `.map()`. Caching the result in a variable avoids the double call on every render of the table.

```suggestion
                    <td>
                      {(() => {
                        const jobs = activeJobs(repository);
                        return jobs.length === 0 ? (
                          <span>None</span>
                        ) : (
                          <div className="code-indexer-admin__job-stack">
                            {jobs.map((job) => (
```


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["Preserve Code Indexer dashboard notices"](https://github.com/astandrik/ydb-qdrant-ui/commit/5d175f98cb6883a270b4bea51fdef38c542b2087) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33812304)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->